### PR TITLE
Fix mobile layout for Alerts mark-all button

### DIFF
--- a/realestate-broker-ui/app/api/assets/[id]/share-message/route.test.ts
+++ b/realestate-broker-ui/app/api/assets/[id]/share-message/route.test.ts
@@ -13,7 +13,9 @@ describe('/api/assets/[id]/share-message', () => {
     ;(global.fetch as any).mockResolvedValue({
       ok: true,
       status: 200,
-      json: async () => ({ message: 'msg' })
+      headers: { get: () => 'application/json' },
+      json: async () => ({ message: 'msg' }),
+      text: async () => JSON.stringify({ message: 'msg' })
     })
     const req = new NextRequest(
       'http://localhost:3000/api/assets/1/share-message',
@@ -42,7 +44,10 @@ describe('/api/assets/[id]/share-message', () => {
     ;(global.fetch as any).mockResolvedValue({
       ok: false,
       status: 500,
-      json: async () => ({ error: 'fail' })
+      statusText: 'Internal Server Error',
+      headers: { get: () => 'text/plain' },
+      json: async () => ({ error: 'fail' }),
+      text: async () => 'fail'
     })
 
     const req = new NextRequest(

--- a/realestate-broker-ui/components/layout/dashboard-shell.tsx
+++ b/realestate-broker-ui/components/layout/dashboard-shell.tsx
@@ -27,12 +27,12 @@ export function DashboardHeader({
   children,
 }: DashboardHeaderProps) {
   return (
-    <div className="flex items-center justify-between px-2">
+    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between px-2">
       <div className="grid gap-1">
         <h1 className="font-bold text-2xl md:text-3xl lg:text-4xl">{heading}</h1>
         {text && <p className="text-base md:text-lg text-muted-foreground">{text}</p>}
       </div>
-      {children}
+      {children && <div className="w-full sm:w-auto">{children}</div>}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- make DashboardHeader responsive so alert actions stack on mobile
- adjust share-message route tests to mock headers and text

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68ac6ff716ac83289240228bc1ce9585