### PR TITLE
Use numeric asset IDs across routes

### DIFF
--- a/backend-django/core/urls.py
+++ b/backend-django/core/urls.py
@@ -12,7 +12,7 @@ urlpatterns = [
     # Asset enrichment endpoints
     path('assets/', views.assets, name='assets'),
     path('assets/<int:asset_id>/', views.asset_detail, name='asset_detail'),
-    path('assets/<str:asset_id>/share-message/', views.asset_share_message, name='asset_share_message'),
+    path('assets/<int:asset_id>/share-message/', views.asset_share_message, name='asset_share_message'),
     
 
     

--- a/realestate-broker-ui/app/api/assets/[id]/route.test.ts
+++ b/realestate-broker-ui/app/api/assets/[id]/route.test.ts
@@ -6,7 +6,7 @@ import { NextRequest } from 'next/server'
 vi.mock('@/lib/data', () => ({
   assets: [
     {
-      id: 'l1',
+      id: 1,
       address: 'Test Street 123',
       price: 3000000,
       bedrooms: 3,
@@ -18,7 +18,7 @@ vi.mock('@/lib/data', () => ({
       neighborhood: 'מרכז העיר',
     },
     {
-      id: 'l2',
+      id: 2,
       address: 'Another Street 456',
       price: 4200000,
       bedrooms: 4,
@@ -47,23 +47,23 @@ describe('/api/assets/[id]', () => {
 
   describe('GET', () => {
     it('returns asset when found in mock data', async () => {
-      const request = new NextRequest('http://localhost:3000/api/assets/l1')
-      const params = { id: 'l1' }
+      const request = new NextRequest('http://localhost:3000/api/assets/1')
+      const params = { id: '1' }
       
       const response = await GET(request, { params })
       const data = await response.json()
       
       expect(response.status).toBe(200)
       expect(data.asset).toBeDefined()
-      expect(data.asset.id).toBe('l1')
+      expect(data.asset.id).toBe(1)
       expect(data.asset.address).toBe('Test Street 123')
       expect(data.asset.price).toBe(3000000)
       expect(data.asset.city).toBe('תל אביב')
     })
 
     it('returns 404 when asset not found', async () => {
-      const request = new NextRequest('http://localhost:3000/api/assets/nonexistent')
-      const params = { id: 'nonexistent' }
+      const request = new NextRequest('http://localhost:3000/api/assets/999')
+      const params = { id: '999' }
       
       const response = await GET(request, { params })
       
@@ -73,7 +73,7 @@ describe('/api/assets/[id]', () => {
 
     it('prefers backend data when available', async () => {
       const mockBackendAsset = {
-        id: 'backend1',
+        id: 101,
         address: 'Backend Street 789',
         price: 5000000,
         size: 100,
@@ -88,22 +88,22 @@ describe('/api/assets/[id]', () => {
         })
       })
 
-      const request = new NextRequest('http://localhost:3000/api/assets/backend1')
-      const params = { id: 'backend1' }
+      const request = new NextRequest('http://localhost:3000/api/assets/101')
+      const params = { id: '101' }
       
       const response = await GET(request, { params })
       const data = await response.json()
       
       expect(response.status).toBe(200)
       expect(data.asset).toBeDefined()
-      expect(data.asset.id).toBe('backend1')
+      expect(data.asset.id).toBe(101)
       expect(data.asset.address).toBe('Backend Street 789')
       expect(data.asset.price).toBe(5000000)
       expect(data.asset.type).toBe('פנטהאוס')
       
       // Verify backend was called
       expect(global.fetch).toHaveBeenCalledWith(
-        'http://localhost:8000/api/assets/backend1'
+        'http://localhost:8000/api/assets/101'
       )
     })
 
@@ -111,15 +111,15 @@ describe('/api/assets/[id]', () => {
       // Mock backend failure
       ;(global.fetch as any).mockRejectedValue(new Error('Backend unavailable'))
 
-      const request = new NextRequest('http://localhost:3000/api/assets/l1')
-      const params = { id: 'l1' }
+      const request = new NextRequest('http://localhost:3000/api/assets/1')
+      const params = { id: '1' }
       
       const response = await GET(request, { params })
       const data = await response.json()
       
       expect(response.status).toBe(200)
       expect(data.asset).toBeDefined()
-      expect(data.asset.id).toBe('l1')
+      expect(data.asset.id).toBe(1)
       expect(data.asset.address).toBe('Test Street 123')
     })
 
@@ -133,8 +133,8 @@ describe('/api/assets/[id]', () => {
         )
       )
 
-      const request = new NextRequest('http://localhost:3000/api/assets/l1')
-      const params = { id: 'l1' }
+      const request = new NextRequest('http://localhost:3000/api/assets/1')
+      const params = { id: '1' }
       
       try {
         const response = await GET(request, { params })
@@ -142,7 +142,7 @@ describe('/api/assets/[id]', () => {
         
         expect(response.status).toBe(200)
         expect(data.asset).toBeDefined()
-        expect(data.asset.id).toBe('l1')
+        expect(data.asset.id).toBe(1)
       } finally {
         consoleSpy.mockRestore()
       }
@@ -150,8 +150,8 @@ describe('/api/assets/[id]', () => {
 
     it('transforms backend data correctly', async () => {
       const mockBackendAsset = {
-        id: 'transform1',
-        external_id: 'ext123',
+        id: 102,
+        external_id: 202,
         address: 'Transform Street 999',
         price: 2500000,
         size: 75,
@@ -175,8 +175,8 @@ describe('/api/assets/[id]', () => {
         })
       })
 
-      const request = new NextRequest('http://localhost:3000/api/assets/transform1')
-      const params = { id: 'transform1' }
+      const request = new NextRequest('http://localhost:3000/api/assets/102')
+      const params = { id: '102' }
       
       const response = await GET(request, { params })
       const data = await response.json()
@@ -185,7 +185,7 @@ describe('/api/assets/[id]', () => {
       expect(data.asset).toBeDefined()
       
       const asset = data.asset
-      expect(asset.id).toBe('transform1')
+      expect(asset.id).toBe(102)
       expect(asset.address).toBe('Transform Street 999')
       expect(asset.price).toBe(2500000)
       expect(asset.bedrooms).toBe(2.5)
@@ -210,7 +210,7 @@ describe('/api/assets/[id]', () => {
 
     it('uses external_id when id is not available in backend data', async () => {
       const mockBackendAsset = {
-        external_id: 'ext456',
+        external_id: 103,
         address: 'External ID Street',
         price: 3500000,
         size: 90,
@@ -224,14 +224,14 @@ describe('/api/assets/[id]', () => {
         })
       })
 
-      const request = new NextRequest('http://localhost:3000/api/assets/ext456')
-      const params = { id: 'ext456' }
+      const request = new NextRequest('http://localhost:3000/api/assets/103')
+      const params = { id: '103' }
       
       const response = await GET(request, { params })
       const data = await response.json()
       
       expect(response.status).toBe(200)
-      expect(data.asset.id).toBe('ext456')
+      expect(data.asset.id).toBe(103)
     })
   })
 })

--- a/realestate-broker-ui/app/api/assets/[id]/route.ts
+++ b/realestate-broker-ui/app/api/assets/[id]/route.ts
@@ -14,12 +14,12 @@ export async function GET(
     if (backendResponse.ok) {
       const data = await backendResponse.json()
       const backendAsset = data.rows?.find((l: any) =>
-        l.id?.toString() === id || l.external_id === id
+        l.id?.toString() === id || l.external_id?.toString() === id
       )
 
       if (backendAsset) {
         const asset = {
-          id: backendAsset.id?.toString() || backendAsset.external_id,
+          id: Number(backendAsset.id ?? backendAsset.external_id),
           address: backendAsset.address,
           price: backendAsset.price,
           bedrooms: backendAsset.rooms || 3,
@@ -93,7 +93,7 @@ export async function GET(
   }
 
   // Fallback to mock data
-  const asset = assets.find(l => l.id === id)
+  const asset = assets.find(l => l.id === Number(id))
   if(!asset) return new NextResponse('Not found', { status: 404, statusText: 'Not Found' })
   return NextResponse.json({ asset })
 }

--- a/realestate-broker-ui/app/api/assets/[id]/share-message/route.test.ts
+++ b/realestate-broker-ui/app/api/assets/[id]/share-message/route.test.ts
@@ -13,6 +13,7 @@ describe('/api/assets/[id]/share-message', () => {
     ;(global.fetch as any).mockResolvedValue({
       ok: true,
       status: 200,
+      headers: { get: () => 'application/json' },
       json: async () => ({ message: 'msg' })
     })
     const req = new NextRequest(
@@ -42,7 +43,10 @@ describe('/api/assets/[id]/share-message', () => {
     ;(global.fetch as any).mockResolvedValue({
       ok: false,
       status: 500,
-      json: async () => ({ error: 'fail' })
+      statusText: 'Server Error',
+      headers: { get: () => 'application/json' },
+      json: async () => ({ error: 'fail' }),
+      text: async () => JSON.stringify({ error: 'fail' })
     })
 
     const req = new NextRequest(

--- a/realestate-broker-ui/app/api/assets/route.ts
+++ b/realestate-broker-ui/app/api/assets/route.ts
@@ -22,7 +22,7 @@ export async function GET() {
   try {
     // Return mock data for now
     const transformedRows = assets.map((asset: any) => ({
-      id: asset.id?.toString(),
+      id: asset.id,
       address: asset.address,
       price: asset.price,
       bedrooms: asset.bedrooms || 0,
@@ -79,7 +79,7 @@ export async function POST(req: Request) {
     
     // Create asset with available data, using defaults for missing fields
     const asset: Asset = {
-      id: `asset_${Date.now()}`, // Generate unique ID
+      id: Date.now(), // Generate unique numeric ID
       address: validatedData.address,
       price: 0, // Will be populated by enrichment pipeline
       bedrooms: 0,

--- a/realestate-broker-ui/app/api/reports/route.ts
+++ b/realestate-broker-ui/app/api/reports/route.ts
@@ -24,7 +24,8 @@ export async function GET(req: Request) {
 }
 
 export async function POST(req: Request) {
-  const { assetId } = await req.json();
+  const body = await req.json();
+  const assetId = Number(body.assetId);
 
   if (BACKEND_URL) {
     try {
@@ -74,8 +75,8 @@ if (!asset) {
 
   const report: Report = {
     id,
-            assetId,
-        address: asset.address,
+    assetId,
+    address: asset.address,
     filename,
     createdAt: new Date().toISOString(),
   };

--- a/realestate-broker-ui/app/assets/[id]/page.tsx
+++ b/realestate-broker-ui/app/assets/[id]/page.tsx
@@ -107,7 +107,7 @@ export default function AssetDetail({ params }: { params: { id: string } }) {
       const res = await fetch('/api/reports', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ assetId: id })
+        body: JSON.stringify({ assetId: Number(id) })
       })
       if (res.ok) {
         router.push('/reports')

--- a/realestate-broker-ui/app/reports/page.test.tsx
+++ b/realestate-broker-ui/app/reports/page.test.tsx
@@ -16,7 +16,7 @@ vi.mock('@/components/layout/dashboard-layout', () => ({
 describe('ReportsPage', () => {
   it('loads and displays reports from the API', async () => {
     const sampleReports = [
-      { id: 'r1', assetId: 'l1', address: 'Demo St 1', filename: 'r1.pdf', createdAt: new Date().toISOString() }
+      { id: 'r1', assetId: 1, address: 'Demo St 1', filename: 'r1.pdf', createdAt: new Date().toISOString() }
     ];
 
     const fetchMock = vi.fn().mockResolvedValue({
@@ -29,7 +29,7 @@ describe('ReportsPage', () => {
     // Wait for the report address to appear in the main link
     const reportLink = await screen.findByRole('link', { name: 'Demo St 1' });
     expect(reportLink).toBeInTheDocument();
-    expect(reportLink).toHaveAttribute('href', '/assets/l1');
+    expect(reportLink).toHaveAttribute('href', '/assets/1');
     
     // Verify the API was called
     expect(fetchMock).toHaveBeenCalledWith('/api/reports');

--- a/realestate-broker-ui/app/reports/page.tsx
+++ b/realestate-broker-ui/app/reports/page.tsx
@@ -12,7 +12,7 @@ import Link from 'next/link'
 
 type Report = {
   id: string
-          assetId: string
+  assetId: number
   address: string
   filename: string
   createdAt: string
@@ -45,7 +45,7 @@ export default function ReportsPage() {
   const sampleReports: Report[] = [
     {
       id: '1',
-              assetId: '1',
+      assetId: 1,
       address: 'רחוב הרצל 123, תל אביב',
       filename: 'report_1.pdf',
       createdAt: new Date().toISOString(),
@@ -54,7 +54,7 @@ export default function ReportsPage() {
     },
     {
       id: '2',
-              assetId: '2',
+      assetId: 2,
       address: 'רחוב דיזנגוף 45, תל אביב',
       filename: 'report_2.pdf',
       createdAt: new Date(Date.now() - 86400000).toISOString(), // 1 day ago

--- a/realestate-broker-ui/lib/data.test.ts
+++ b/realestate-broker-ui/lib/data.test.ts
@@ -66,9 +66,9 @@ describe('Data Module', () => {
 
   describe('appraisalByAsset', () => {
     it('returns appraisal data for valid asset ID', () => {
-      const result = appraisalByAsset('l1')
-      
-      expect(result).toHaveProperty('assetId', 'l1')
+      const result = appraisalByAsset(1)
+
+      expect(result).toHaveProperty('assetId', 1)
       expect(result).toHaveProperty('marketValue')
       expect(result).toHaveProperty('appraisedValue')
       expect(result).toHaveProperty('date')
@@ -79,17 +79,17 @@ describe('Data Module', () => {
     })
 
     it('returns default data for unknown asset ID', () => {
-      const result = appraisalByAsset('unknown')
-      
-      expect(result).toHaveProperty('assetId', 'unknown')
+      const result = appraisalByAsset(999)
+
+      expect(result).toHaveProperty('assetId', 999)
       expect(result).toHaveProperty('marketValue')
       expect(typeof result.marketValue).toBe('number')
     })
 
     it('has valid structure with expected fields', () => {
-      const result = appraisalByAsset('l1')
-      
-      expect(result.assetId).toBe('l1')
+      const result = appraisalByAsset(1)
+
+      expect(result.assetId).toBe(1)
       expect(result.marketValue).toBe(2850000)
       expect(result.appraisedValue).toBe(2800000)
       expect(typeof result.date).toBe('string')
@@ -100,21 +100,21 @@ describe('Data Module', () => {
 
   describe('compsByAsset', () => {
     it('returns comparison data for valid asset ID', () => {
-      const result = compsByAsset('l1')
+      const result = compsByAsset(1)
       
       expect(Array.isArray(result)).toBe(true)
       expect(result.length).toBeGreaterThan(0)
     })
 
     it('returns default data for unknown asset ID', () => {
-      const result = compsByAsset('unknown')
+      const result = compsByAsset(999)
       
       expect(Array.isArray(result)).toBe(true)
       expect(result.length).toBeGreaterThan(0)
     })
 
     it('has valid comparable property structure', () => {
-      const result = compsByAsset('l1')
+      const result = compsByAsset(1)
       
       result.forEach(prop => {
         expect(prop).toHaveProperty('address')
@@ -133,9 +133,9 @@ describe('Data Module', () => {
 
   describe('rightsByAsset', () => {
     it('returns rights data for valid asset ID', () => {
-      const result = rightsByAsset('l1')
-      
-      expect(result).toHaveProperty('assetId', 'l1')
+      const result = rightsByAsset(1)
+
+      expect(result).toHaveProperty('assetId', 1)
       expect(result).toHaveProperty('buildingRights')
       expect(result).toHaveProperty('landUse')
       expect(result).toHaveProperty('restrictions')
@@ -146,17 +146,17 @@ describe('Data Module', () => {
     })
 
     it('returns default data for unknown asset ID', () => {
-      const result = rightsByAsset('unknown')
-      
-      expect(result).toHaveProperty('assetId', 'unknown')
+      const result = rightsByAsset(999)
+
+      expect(result).toHaveProperty('assetId', 999)
       expect(result).toHaveProperty('buildingRights')
       expect(typeof result.buildingRights).toBe('string')
     })
 
     it('has valid structure with expected fields', () => {
-      const result = rightsByAsset('l1')
-      
-      expect(result.assetId).toBe('l1')
+      const result = rightsByAsset(1)
+
+      expect(result.assetId).toBe(1)
       expect(typeof result.buildingRights).toBe('string')
       expect(typeof result.landUse).toBe('string')
       expect(typeof result.lastUpdate).toBe('string')
@@ -203,7 +203,7 @@ describe('Data Module', () => {
 
     it('adds a new asset to the assets array', () => {
       const newAsset: Asset = {
-        id: 'test-asset',
+        id: 999,
         address: 'Test Street 123',
         price: 2000000,
         bedrooms: 3,
@@ -229,7 +229,7 @@ describe('Data Module', () => {
 
     it('maintains asset array structure after adding', () => {
       const newAsset: Asset = {
-        id: 'test-asset-2',
+        id: 1000,
         address: 'Another Test Street 456',
         price: 3500000,
         bedrooms: 4,
@@ -252,7 +252,7 @@ describe('Data Module', () => {
       addAsset(newAsset)
       
       const addedAsset = assets[assets.length - 1]
-      expect(addedAsset).toHaveProperty('id', 'test-asset-2')
+      expect(addedAsset).toHaveProperty('id', 1000)
       expect(addedAsset).toHaveProperty('city', 'תל אביב')
       expect(addedAsset).toHaveProperty('neighborhood', 'מרכז העיר')
       expect(addedAsset.features).toEqual(['garden', 'garage'])

--- a/realestate-broker-ui/lib/data.ts
+++ b/realestate-broker-ui/lib/data.ts
@@ -1,5 +1,5 @@
 export interface Asset {
-  id: string
+  id: number
   address: string
   price: number
   bedrooms: number
@@ -70,7 +70,7 @@ export interface Asset {
 
 export const assets: Asset[] = [
   {
-    id: "l1",
+    id: 1,
     address: "רחוב הרצל 123, תל אביב",
     price: 2850000,
     bedrooms: 3,
@@ -87,12 +87,12 @@ export const assets: Asset[] = [
       email: "yossi@example.com"
     },
     documents: [
-      { name: "נסח טאבו", url: "/docs/l1/tabu.pdf", type: "tabu" },
-      { name: "תשריט בית משותף", url: "/docs/l1/condo-plan.pdf", type: "condo_plan" },
-      { name: "היתר בנייה", url: "/docs/l1/permit.pdf", type: "permit" },
-      { name: "זכויות בנייה", url: "/docs/l1/rights.pdf", type: "rights" },
-      { name: "שומת מכרעת", url: "/docs/l1/decisive-appraisal.pdf", type: "appraisal_decisive" },
-      { name: "שומת רמ״י", url: "/docs/l1/rmi-appraisal.pdf", type: "appraisal_rmi" }
+      { name: "נסח טאבו", url: "/docs/1/tabu.pdf", type: "tabu" },
+      { name: "תשריט בית משותף", url: "/docs/1/condo-plan.pdf", type: "condo_plan" },
+      { name: "היתר בנייה", url: "/docs/1/permit.pdf", type: "permit" },
+      { name: "זכויות בנייה", url: "/docs/1/rights.pdf", type: "rights" },
+      { name: "שומת מכרעת", url: "/docs/1/decisive-appraisal.pdf", type: "appraisal_decisive" },
+      { name: "שומת רמ״י", url: "/docs/1/rmi-appraisal.pdf", type: "appraisal_rmi" }
     ],
     city: "תל אביב",
     neighborhood: "מרכז העיר",
@@ -123,7 +123,7 @@ export const assets: Asset[] = [
     permitMainArea: 120,
     permitServiceArea: 30,
     permitApplicant: 'בעלים',
-    permitDocUrl: '/docs/l1/permit.pdf',
+    permitDocUrl: '/docs/1/permit.pdf',
     mainRightsSqm: 150,
     serviceRightsSqm: 40,
     additionalPlanRights: 'תב"ע 1234',
@@ -140,7 +140,7 @@ export const assets: Asset[] = [
     bettermentLevy: 'היטל צפוי כ-50 אלף ₪'
   },
   {
-    id: "l2",
+    id: 2,
     address: "שדרות רוטשילד 45, תל אביב",
     price: 4200000,
     bedrooms: 4,
@@ -157,9 +157,9 @@ export const assets: Asset[] = [
       email: "dana@example.com"
     },
     documents: [
-      { name: "נסח טאבו", url: "/docs/l2/tabu.pdf", type: "tabu" },
-      { name: "היתר בנייה", url: "/docs/l2/permit.pdf", type: "permit" },
-      { name: "שומת רמ״י", url: "/docs/l2/rmi-appraisal.pdf", type: "appraisal_rmi" }
+      { name: "נסח טאבו", url: "/docs/2/tabu.pdf", type: "tabu" },
+      { name: "היתר בנייה", url: "/docs/2/permit.pdf", type: "permit" },
+      { name: "שומת רמ״י", url: "/docs/2/rmi-appraisal.pdf", type: "appraisal_rmi" }
     ],
     city: "תל אביב",
     neighborhood: "רוטשילד",
@@ -188,7 +188,7 @@ export const assets: Asset[] = [
 ]
 
 // Mock data functions for API routes
-export function appraisalByAsset(id: string) {
+export function appraisalByAsset(id: number) {
   return {
     assetId: id,
     marketValue: 2850000,
@@ -199,7 +199,7 @@ export function appraisalByAsset(id: string) {
   }
 }
 
-export function compsByAsset(id: string) {
+export function compsByAsset(id: number) {
   return [
     {
       address: "רחוב בן יהודה 45, תל אביב",
@@ -218,7 +218,7 @@ export function compsByAsset(id: string) {
   ]
 }
 
-export function rightsByAsset(id: string) {
+export function rightsByAsset(id: number) {
   return {
     assetId: id,
     buildingRights: "זכויות בנייה: 4 קומות + גג",
@@ -235,7 +235,7 @@ export interface Alert {
   type: 'price_drop' | 'new_asset' | 'market_change' | 'document_update' | 'permit_status'
   title: string
   message: string
-      assetId?: string
+      assetId?: number
     assetAddress?: string
   priority: 'high' | 'medium' | 'low'
   isRead: boolean
@@ -249,15 +249,15 @@ export const alerts: Alert[] = [
     type: "price_drop",
     title: "ירידת מחיר בנכס",
     message: "הנכס ברחוב הרצל 123 ירד במחיר ב-50,000 ₪",
-    assetId: "l1",
+    assetId: 1,
     assetAddress: "רחוב הרצל 123, תל אביב",
     priority: "high",
     isRead: false,
     createdAt: "2024-01-15T10:30:00Z",
-    actionUrl: "/assets/l1"
+    actionUrl: "/assets/1"
   },
   {
-    id: "alert2", 
+    id: "alert2",
     type: "new_asset",
     title: "נכס חדש התווסף",
     message: "נכס חדש במרכז תל אביב התאים לקריטריונים שלך - 3 חדרים, עד 3M ₪",
@@ -279,24 +279,24 @@ export const alerts: Alert[] = [
     type: "document_update",
     title: "עדכון מסמכים",
     message: "תוכנית בנייה חדשה פורסמה לאזור רוטשילד - עלולה להשפיע על ערך הנכס",
-    assetId: "l2",
-    assetAddress: "שדרות רוטשילד 45, תל אביב", 
+    assetId: 2,
+    assetAddress: "שדרות רוטשילד 45, תל אביב",
     priority: "high",
     isRead: true,
     createdAt: "2024-01-12T14:20:00Z",
-    actionUrl: "/assets/l2"
+    actionUrl: "/assets/2"
   },
   {
     id: "alert5",
     type: "permit_status",
     title: "עדכון היתר בנייה",
     message: "היתר הבנייה עבור הנכס ברוטשילד אושר - ניתן להתחיל בעבודות",
-    assetId: "l2",
+    assetId: 2,
     assetAddress: "שדרות רוטשילד 45, תל אביב",
     priority: "low",
     isRead: true,
     createdAt: "2024-01-10T11:15:00Z",
-    actionUrl: "/assets/l2"
+    actionUrl: "/assets/2"
   }
 ]
 

--- a/realestate-broker-ui/lib/reports.ts
+++ b/realestate-broker-ui/lib/reports.ts
@@ -1,6 +1,6 @@
 export interface Report {
   id: string;
-  assetId: string;
+  assetId: number;
   address: string;
   filename: string;
   createdAt: string;
@@ -9,7 +9,7 @@ export interface Report {
 export const reports: Report[] = [
   {
     id: 'r1',
-    assetId: 'l1',
+    assetId: 1,
     address: 'רחוב הרצל 123, תל אביב',
     filename: 'r1.pdf',
     createdAt: '2024-01-15T08:00:00.000Z',


### PR DESCRIPTION
## Summary
- keep asset identifiers numeric and update sample data and tests
- adjust asset detail and share-message endpoints for numeric IDs
- ensure reporting and API routes send numeric asset IDs

## Testing
- `npm test -- --run`
- `pytest` *(fails: ProxyError in GIS tests, assertions in Yad2 tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ad007ddb4083289a6a664d2373f718