### PR TITLE
Ensure settings API uses trailing slash

### DIFF
--- a/realestate-broker-ui/app/settings/page.tsx
+++ b/realestate-broker-ui/app/settings/page.tsx
@@ -37,7 +37,7 @@ export default function SettingsPage() {
   useEffect(() => {
     const load = async () => {
       try {
-        const res = await fetch('/api/settings')
+        const res = await fetch('/api/settings/')
         if (res.ok) {
           const data = await res.json()
           setSettings(data)
@@ -51,7 +51,7 @@ export default function SettingsPage() {
 
   const handleSave = async () => {
     try {
-      const res = await fetch('/api/settings', {
+      const res = await fetch('/api/settings/', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(settings)


### PR DESCRIPTION
## Summary
- fix settings page API calls to include trailing slash
- ensure settings save/load requests hit correct backend endpoint

## Testing
- `pytest tests/core/test_user_settings.py`
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad397ed8b483288d4c01cf8dd5aaa7