### PR TITLE
feat: display marketing message errors in UI

### DIFF
--- a/realestate-broker-ui/app/assets/[id]/page.test.tsx
+++ b/realestate-broker-ui/app/assets/[id]/page.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import AssetDetailPage from './page'
+import { useRouter } from 'next/navigation'
+
+vi.mock('next/navigation')
+vi.mock('@/components/layout/dashboard-layout', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>
+}))
+vi.mock('@/components/ui/page-loader', () => ({
+  PageLoader: () => <div>Loading...</div>
+}))
+
+describe('AssetDetailPage', () => {
+  const mockUseRouter = { push: vi.fn() }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(useRouter as any).mockReturnValue(mockUseRouter)
+    global.fetch = vi.fn((url: string, options?: any) => {
+      if (url === '/api/assets/1') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: '1',
+            address: 'Test Street 1',
+            city: 'Tel Aviv',
+            type: 'house',
+            netSqm: 80,
+            price: 1000000,
+            pricePerSqm: 12500,
+            documents: [],
+          })
+        })
+      }
+      if (url === '/api/assets/1/share-message') {
+        return Promise.resolve({
+          ok: false,
+          json: async () => ({ details: 'Quota exceeded' })
+        })
+      }
+      return Promise.reject(new Error('Unhandled fetch call'))
+    }) as any
+  })
+
+  it('shows error message when message creation fails', async () => {
+    await act(async () => {
+      render(<AssetDetailPage params={{ id: '1' }} />)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('צור הודעת פרסום')).toBeInTheDocument()
+    })
+
+    const button = screen.getByText('צור הודעת פרסום')
+    await act(async () => {
+      fireEvent.click(button)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Quota exceeded')).toBeInTheDocument()
+    })
+  })
+})

--- a/realestate-broker-ui/app/assets/[id]/page.tsx
+++ b/realestate-broker-ui/app/assets/[id]/page.tsx
@@ -20,6 +20,7 @@ export default function AssetDetail({ params }: { params: { id: string } }) {
   const [syncMessage, setSyncMessage] = useState<string>('')
   const [creatingMessage, setCreatingMessage] = useState(false)
   const [shareMessage, setShareMessage] = useState<string | null>(null)
+  const [shareError, setShareError] = useState<string | null>(null)
   const [language, setLanguage] = useState('he')
   const router = useRouter()
   const { id } = params
@@ -123,6 +124,7 @@ export default function AssetDetail({ params }: { params: { id: string } }) {
     if (!id) return
     setCreatingMessage(true)
     setShareMessage(null)
+    setShareError(null)
     try {
       const res = await fetch(`/api/assets/${id}/share-message`, {
         method: 'POST',
@@ -132,9 +134,13 @@ export default function AssetDetail({ params }: { params: { id: string } }) {
       if (res.ok) {
         const data = await res.json()
         setShareMessage(data.message)
+      } else {
+        const errorData = await res.json().catch(() => ({}))
+        setShareError(errorData.details || errorData.error || 'שגיאה ביצירת הודעה')
       }
     } catch (err) {
       console.error('Message generation failed:', err)
+      setShareError('שגיאה ביצירת הודעה')
     } finally {
       setCreatingMessage(false)
     }
@@ -271,6 +277,9 @@ export default function AssetDetail({ params }: { params: { id: string } }) {
                   העתק הודעה
                 </Button>
               </div>
+            )}
+            {shareError && (
+              <div className="text-sm text-red-500">{shareError}</div>
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- handle share-message API failures and surface error details to users
- test marketing message failure flow for asset detail page

## Testing
- `cd realestate-broker-ui && npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68ad3cb6d83c8328baebb7c110636d33