### PR TITLE
Fix profile & settings visibility on tall pages

### DIFF
--- a/realestate-broker-ui/components/layout/dashboard-layout.tsx
+++ b/realestate-broker-ui/components/layout/dashboard-layout.tsx
@@ -13,7 +13,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
   const [sidebarOpen, setSidebarOpen] = React.useState(true)
 
   return (
-    <div className="flex min-h-[100dvh] overflow-hidden">
+    <div className="flex h-[100dvh] overflow-hidden">
       {/* Sidebar - hidden on mobile, sticky on desktop */}
       <div className="hidden md:flex-shrink-0 md:block">
         <AppSidebar isCollapsed={!sidebarOpen} />


### PR DESCRIPTION
## Summary
- ensure dashboard sidebar uses fixed viewport height so profile/settings stay visible

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae7c6add8c8328955ab0a3ce4ee47a