### PR TITLE
feat: add mobile header logo

### DIFF
--- a/realestate-broker-ui/components/layout/header.tsx
+++ b/realestate-broker-ui/components/layout/header.tsx
@@ -155,6 +155,9 @@ export default function Header({ onToggleSidebar }: HeaderProps) {
           </SheetContent>
         </Sheet>
 
+        <Link href="/" className="md:hidden" aria-label="עמוד הבית">
+          <Logo variant="symbol" size={28} color="var(--brand-teal)" />
+        </Link>
         <GlobalSearch />
       </div>
 


### PR DESCRIPTION
## Summary
- add logo to mobile header for branding and quick home navigation

## Testing
- `npm test -- --run`
- `npm run lint`
- `pytest` *(fails: requests.exceptions.ProxyError in tests/gis/test_privilege_page.py::test_privilege_page, assert False in tests/yad2/test_mcp_server.py::TestLocationServices::test_search_locations, assert False is True in tests/yad2/test_mcp_server.py::TestSearchFunctionality::test_search_real_estate, assert False is True in tests/yad2/test_mcp_server.py::TestIntegration::test_property_search_workflow, AttributeError: 'NoneType' object has no attribute ... in tests/yad2/test_mcp_server.py::TestIntegration::test_location_workflow)*

------
https://chatgpt.com/codex/tasks/task_e_68ae848c58b88328867595d1265a7a05