### PR TITLE
fix: show header logo on desktop

### DIFF
--- a/realestate-broker-ui/components/layout/header.tsx
+++ b/realestate-broker-ui/components/layout/header.tsx
@@ -155,7 +155,7 @@ export default function Header({ onToggleSidebar }: HeaderProps) {
           </SheetContent>
         </Sheet>
 
-        <Link href="/" className="md:hidden" aria-label="עמוד הבית">
+        <Link href="/" aria-label="עמוד הבית">
           <Logo variant="symbol" size={28} color="var(--brand-teal)" />
         </Link>
         <GlobalSearch />


### PR DESCRIPTION
## Summary
- display site logo in header for desktop view

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae88c77928832883524098810c66ae