### PR TITLE
Link top areas to filtered assets

### DIFF
--- a/realestate-broker-ui/__tests__/integration/asset-management.test.tsx
+++ b/realestate-broker-ui/__tests__/integration/asset-management.test.tsx
@@ -10,11 +10,14 @@ import { NextRouter } from 'next/router'
 import AssetsPage from '../../app/assets/page'
 import AssetDetailPage from '../../app/assets/[id]/page'
 import { useAuth } from '@/lib/auth-context'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 
 // Mock dependencies
 vi.mock('@/lib/auth-context')
-vi.mock('next/navigation')
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(),
+  useSearchParams: vi.fn(),
+}))
 vi.mock('@/components/AssetsTable', () => ({
   default: ({ data, loading }: { data: any[], loading: boolean }) => (
     <div data-testid="assets-table">
@@ -55,6 +58,10 @@ const mockUseRouter = {
   prefetch: vi.fn()
 }
 
+const mockUseSearchParams = {
+  get: vi.fn(),
+}
+
 const mockUseAuth = {
   isAuthenticated: true,
   user: { id: '1', name: 'Test User', email: 'test@example.com' },
@@ -69,6 +76,8 @@ describe('Asset Management Integration', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     ;(useRouter as any).mockReturnValue(mockUseRouter)
+    ;(useSearchParams as any).mockReturnValue(mockUseSearchParams)
+    mockUseSearchParams.get.mockReturnValue(null)
     ;(useAuth as any).mockReturnValue(mockUseAuth)
     
     // Default fetch responses

--- a/realestate-broker-ui/app/assets/page.test.tsx
+++ b/realestate-broker-ui/app/assets/page.test.tsx
@@ -3,11 +3,14 @@ import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import AssetsPage from './page'
 import { useAuth } from '@/lib/auth-context'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 
 // Mock dependencies
 vi.mock('@/lib/auth-context')
-vi.mock('next/navigation')
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(),
+  useSearchParams: vi.fn(),
+}))
 vi.mock('@/components/layout/dashboard-layout', () => ({
   default: ({ children }: { children: React.ReactNode }) => <div data-testid="dashboard-layout">{children}</div>
 }))
@@ -32,6 +35,10 @@ const mockUseRouter = {
   prefetch: vi.fn()
 }
 
+const mockUseSearchParams = {
+  get: vi.fn(),
+}
+
 const mockUseAuth = {
   isAuthenticated: true,
   user: { id: '1', name: 'Test User' },
@@ -44,6 +51,8 @@ describe('AssetsPage', () => {
     vi.clearAllMocks()
     mockUseAuth.isAuthenticated = true
     ;(useRouter as any).mockReturnValue(mockUseRouter)
+    ;(useSearchParams as any).mockReturnValue(mockUseSearchParams)
+    mockUseSearchParams.get.mockReturnValue(null)
     ;(useAuth as any).mockReturnValue(mockUseAuth)
 
     // Default successful fetch mock
@@ -251,6 +260,41 @@ describe('AssetsPage', () => {
     // Test city filter - the city filter is handled in the component state
     // and the actual filtering happens in the AssetsTable component
     expect(screen.getByTestId('assets-table')).toBeInTheDocument()
+  })
+
+  it('applies city filter from query params', async () => {
+    mockUseSearchParams.get.mockReturnValue('חיפה')
+    ;(global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        rows: [
+          {
+            id: 'asset1',
+            address: 'Haifa Street 1',
+            price: 3000000,
+            city: 'חיפה',
+            type: 'דירה',
+            asset_status: 'active'
+          },
+          {
+            id: 'asset2',
+            address: 'Tel Aviv Street 2',
+            price: 4200000,
+            city: 'תל אביב',
+            type: 'בית',
+            asset_status: 'pending'
+          }
+        ]
+      })
+    })
+
+    await act(async () => {
+      render(<AssetsPage />)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('1 assets')).toBeInTheDocument()
+    })
   })
 
   it('filters assets by price range', async () => {

--- a/realestate-broker-ui/app/assets/page.tsx
+++ b/realestate-broker-ui/app/assets/page.tsx
@@ -35,14 +35,15 @@ import { useAuth } from "@/lib/auth-context";
 import { Asset } from "@/lib/data";
 import AssetsTable from "@/components/AssetsTable";
 import DashboardLayout from "@/components/layout/dashboard-layout";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 
 export default function AssetsPage() {
   const [assets, setAssets] = useState<Asset[]>([]);
   const [loading, setLoading] = useState(true);
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
-  const [city, setCity] = useState("all");
+  const searchParams = useSearchParams();
+  const [city, setCity] = useState<string>(() => searchParams.get("city") ?? "all");
   const [typeFilter, setTypeFilter] = useState("all");
   const [priceMin, setPriceMin] = useState<number>();
   const [priceMax, setPriceMax] = useState<number>();
@@ -54,6 +55,13 @@ export default function AssetsPage() {
       router.push("/auth?redirect=" + encodeURIComponent("/assets"));
     }
   };
+
+  useEffect(() => {
+    const cityParam = searchParams.get("city");
+    if (cityParam) {
+      setCity(cityParam);
+    }
+  }, [searchParams]);
 
   // Function to fetch assets
   const fetchAssets = async () => {

--- a/realestate-broker-ui/app/page.tsx
+++ b/realestate-broker-ui/app/page.tsx
@@ -344,9 +344,10 @@ export default function HomePage() {
           <CardContent>
             <div className="grid gap-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-4">
               {dashboardData.topAreas.map((area, index) => (
-                <div
+                <Link
                   key={index}
-                  className="p-4 border rounded-lg hover:shadow-md transition-shadow"
+                  href={`/assets?city=${encodeURIComponent(area.area)}`}
+                  className="p-4 border rounded-lg hover:shadow-md transition-shadow block"
                 >
                   <div className="flex items-center justify-between mb-2">
                     <h4 className="font-medium">{area.area}</h4>
@@ -369,7 +370,7 @@ export default function HomePage() {
                   <div className="text-sm text-muted-foreground">
                     {fmtCurrency(area.avgPrice)} ממוצע
                   </div>
-                </div>
+                </Link>
               ))}
             </div>
           </CardContent>


### PR DESCRIPTION
## Summary
- Make top area cards on dashboard link to the assets page with city filter applied
- Read `city` query parameter on assets page to initialize filter
- Add tests for query param filtering and update existing test mocks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae97afce448328bb271c1621082cbb