### PR TITLE
Link top areas to filtered assets

### DIFF
--- a/realestate-broker-ui/__tests__/integration/asset-management.test.tsx
+++ b/realestate-broker-ui/__tests__/integration/asset-management.test.tsx
@@ -10,11 +10,15 @@ import { NextRouter } from 'next/router'
 import AssetsPage from '../../app/assets/page'
 import AssetDetailPage from '../../app/assets/[id]/page'
 import { useAuth } from '@/lib/auth-context'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams, usePathname } from 'next/navigation'
 
 // Mock dependencies
 vi.mock('@/lib/auth-context')
-vi.mock('next/navigation')
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(),
+  useSearchParams: vi.fn(),
+  usePathname: vi.fn(),
+}))
 vi.mock('@/components/AssetsTable', () => ({
   default: ({ data, loading }: { data: any[], loading: boolean }) => (
     <div data-testid="assets-table">
@@ -55,6 +59,11 @@ const mockUseRouter = {
   prefetch: vi.fn()
 }
 
+const mockUseSearchParams = {
+  get: vi.fn(),
+  toString: vi.fn(),
+}
+
 const mockUseAuth = {
   isAuthenticated: true,
   user: { id: '1', name: 'Test User', email: 'test@example.com' },
@@ -69,6 +78,10 @@ describe('Asset Management Integration', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     ;(useRouter as any).mockReturnValue(mockUseRouter)
+    ;(useSearchParams as any).mockReturnValue(mockUseSearchParams)
+    ;(usePathname as any).mockReturnValue('/assets')
+    mockUseSearchParams.get.mockReturnValue(null)
+    mockUseSearchParams.toString.mockReturnValue('')
     ;(useAuth as any).mockReturnValue(mockUseAuth)
     
     // Default fetch responses

--- a/realestate-broker-ui/app/page.tsx
+++ b/realestate-broker-ui/app/page.tsx
@@ -344,9 +344,10 @@ export default function HomePage() {
           <CardContent>
             <div className="grid gap-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-4">
               {dashboardData.topAreas.map((area, index) => (
-                <div
+                <Link
                   key={index}
-                  className="p-4 border rounded-lg hover:shadow-md transition-shadow"
+                  href={`/assets?city=${encodeURIComponent(area.area)}`}
+                  className="p-4 border rounded-lg hover:shadow-md transition-shadow block"
                 >
                   <div className="flex items-center justify-between mb-2">
                     <h4 className="font-medium">{area.area}</h4>
@@ -369,7 +370,7 @@ export default function HomePage() {
                   <div className="text-sm text-muted-foreground">
                     {fmtCurrency(area.avgPrice)} ממוצע
                   </div>
-                </div>
+                </Link>
               ))}
             </div>
           </CardContent>


### PR DESCRIPTION
## Summary
- Make top area cards on dashboard link to the assets page with city filter applied
- Read `city` query parameter on assets page to initialize filter
- Sync city filter changes back to the URL so links remain shareable
- Add tests for query param filtering, URL updates, and update existing test mocks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae97afce448328bb271c1621082cbb