### PR TITLE
feat(ui): sync asset filters with url

### DIFF
--- a/realestate-broker-ui/app/assets/page.test.tsx
+++ b/realestate-broker-ui/app/assets/page.test.tsx
@@ -267,7 +267,9 @@ describe('AssetsPage', () => {
   })
 
   it('applies city filter from query params', async () => {
-    mockUseSearchParams.get.mockReturnValue('חיפה')
+    mockUseSearchParams.get.mockImplementation((key: string) =>
+      key === 'city' ? 'חיפה' : null
+    )
     mockUseSearchParams.toString.mockReturnValue('city=חיפה')
     ;(global.fetch as any).mockResolvedValueOnce({
       ok: true,
@@ -302,6 +304,36 @@ describe('AssetsPage', () => {
     })
   })
 
+  it('applies type filter from query params', async () => {
+    mockUseSearchParams.get.mockImplementation((key: string) =>
+      key === 'type' ? 'דירה' : null
+    )
+    mockUseSearchParams.toString.mockReturnValue('type=דירה')
+
+    await act(async () => {
+      render(<AssetsPage />)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('1 assets')).toBeInTheDocument()
+    })
+  })
+
+  it('applies search filter from query params', async () => {
+    mockUseSearchParams.get.mockImplementation((key: string) =>
+      key === 'search' ? 'Another' : null
+    )
+    mockUseSearchParams.toString.mockReturnValue('search=Another')
+
+    await act(async () => {
+      render(<AssetsPage />)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('1 assets')).toBeInTheDocument()
+    })
+  })
+
   it('updates URL when city filter changes', async () => {
     await act(async () => {
       render(<AssetsPage />)
@@ -319,6 +351,46 @@ describe('AssetsPage', () => {
 
     await waitFor(() => {
       const encoded = new URLSearchParams({ city: 'תל אביב' }).toString()
+      expect(mockUseRouter.replace).toHaveBeenCalledWith(`/assets?${encoded}`, { scroll: false })
+    })
+  })
+
+  it('updates URL when type filter changes', async () => {
+    await act(async () => {
+      render(<AssetsPage />)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('assets-table')).toBeInTheDocument()
+    })
+
+    mockUseRouter.replace.mockClear()
+
+    fireEvent.click(screen.getByText('כל הסוגים'))
+    fireEvent.click(screen.getByText('דירה'))
+
+    await waitFor(() => {
+      const encoded = new URLSearchParams({ type: 'דירה' }).toString()
+      expect(mockUseRouter.replace).toHaveBeenCalledWith(`/assets?${encoded}`, { scroll: false })
+    })
+  })
+
+  it('updates URL when search filter changes', async () => {
+    await act(async () => {
+      render(<AssetsPage />)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('assets-table')).toBeInTheDocument()
+    })
+
+    mockUseRouter.replace.mockClear()
+
+    const searchInput = screen.getByPlaceholderText('חיפוש בכתובת או עיר...')
+    fireEvent.change(searchInput, { target: { value: 'Street' } })
+
+    await waitFor(() => {
+      const encoded = new URLSearchParams({ search: 'Street' }).toString()
       expect(mockUseRouter.replace).toHaveBeenCalledWith(`/assets?${encoded}`, { scroll: false })
     })
   })

--- a/realestate-broker-ui/app/assets/page.tsx
+++ b/realestate-broker-ui/app/assets/page.tsx
@@ -41,12 +41,20 @@ export default function AssetsPage() {
   const [assets, setAssets] = useState<Asset[]>([]);
   const [loading, setLoading] = useState(true);
   const [open, setOpen] = useState(false);
-  const [search, setSearch] = useState("");
   const searchParams = useSearchParams();
+  const [search, setSearch] = useState(() => searchParams.get("search") ?? "");
   const [city, setCity] = useState<string>(() => searchParams.get("city") ?? "all");
-  const [typeFilter, setTypeFilter] = useState("all");
-  const [priceMin, setPriceMin] = useState<number>();
-  const [priceMax, setPriceMax] = useState<number>();
+  const [typeFilter, setTypeFilter] = useState(
+    () => searchParams.get("type") ?? "all"
+  );
+  const [priceMin, setPriceMin] = useState<number | undefined>(() => {
+    const val = searchParams.get("priceMin");
+    return val ? Number(val) : undefined;
+  });
+  const [priceMax, setPriceMax] = useState<number | undefined>(() => {
+    const val = searchParams.get("priceMax");
+    return val ? Number(val) : undefined;
+  });
   const { isAuthenticated } = useAuth();
   const router = useRouter();
   const pathname = usePathname();
@@ -58,18 +66,41 @@ export default function AssetsPage() {
   };
 
   useEffect(() => {
-    const cityParam = searchParams.get("city");
-    if (cityParam) {
-      setCity(cityParam);
-    }
+    setSearch(searchParams.get("search") ?? "");
+    setCity(searchParams.get("city") ?? "all");
+    setTypeFilter(searchParams.get("type") ?? "all");
+    const min = searchParams.get("priceMin");
+    setPriceMin(min ? Number(min) : undefined);
+    const max = searchParams.get("priceMax");
+    setPriceMax(max ? Number(max) : undefined);
   }, [searchParams]);
 
   useEffect(() => {
     const params = new URLSearchParams(searchParams.toString());
+    if (search) {
+      params.set("search", search);
+    } else {
+      params.delete("search");
+    }
     if (city && city !== "all") {
       params.set("city", city);
     } else {
       params.delete("city");
+    }
+    if (typeFilter && typeFilter !== "all") {
+      params.set("type", typeFilter);
+    } else {
+      params.delete("type");
+    }
+    if (priceMin !== undefined) {
+      params.set("priceMin", priceMin.toString());
+    } else {
+      params.delete("priceMin");
+    }
+    if (priceMax !== undefined) {
+      params.set("priceMax", priceMax.toString());
+    } else {
+      params.delete("priceMax");
     }
     const query = params.toString();
     const newUrl = query ? `${pathname}?${query}` : pathname;
@@ -78,7 +109,7 @@ export default function AssetsPage() {
     if (newUrl !== currentUrl) {
       router.replace(newUrl, { scroll: false });
     }
-  }, [city, router, pathname, searchParams]);
+  }, [search, city, typeFilter, priceMin, priceMax, router, pathname, searchParams]);
 
   // Function to fetch assets
   const fetchAssets = async () => {


### PR DESCRIPTION
## Summary
- extend asset list page to sync search, type, and price filters with URL query parameters
- verify filters update URL and can be prefilled from query string

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aea89def20832890c4b41872293f55