### PR TITLE
Determine asset type automatically

### DIFF
--- a/realestate-broker-ui/app/api/assets/[id]/route.ts
+++ b/realestate-broker-ui/app/api/assets/[id]/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { assets } from '@/lib/data'
 
+function determineAssetType(asset: any): string {
+  return asset?.type || asset?.property_type || asset?.propertyType || 'לא ידוע'
+}
+
 export async function GET(
   request: NextRequest,
   { params }: { params: { id: string } }
@@ -25,7 +29,7 @@ export async function GET(
           bedrooms: backendAsset.rooms || 3,
           bathrooms: backendAsset.bathrooms || 2,
           area: backendAsset.size || 85,
-          type: backendAsset.property_type || 'דירה',
+          type: determineAssetType(backendAsset),
           status: 'active',
           images: backendAsset.images || ['/placeholder-home.jpg'],
           description: backendAsset.description || 'תיאור הנכס',

--- a/realestate-broker-ui/app/api/assets/route.test.ts
+++ b/realestate-broker-ui/app/api/assets/route.test.ts
@@ -75,7 +75,7 @@ describe('/api/assets', () => {
       expect(data.asset.address).toBe('New St 5')
       expect(data.asset.city).toBe('תל אביב')
       expect(data.asset.status).toBe('pending')
-      expect(data.asset.type).toBe('דירה')
+      expect(data.asset.type).toBe('לא ידוע')
     })
 
     it('validates required fields', async () => {

--- a/realestate-broker-ui/app/api/assets/route.ts
+++ b/realestate-broker-ui/app/api/assets/route.ts
@@ -18,6 +18,10 @@ const newAssetSchema = z.object({
   radius: z.number().default(100)
 })
 
+function determineAssetType(asset: any): string {
+  return asset?.type || asset?.property_type || asset?.propertyType || 'לא ידוע'
+}
+
 export async function GET() {
   try {
     // Return mock data for now
@@ -28,7 +32,7 @@ export async function GET() {
       bedrooms: asset.bedrooms || 0,
       bathrooms: asset.bathrooms || 1, // Default since not in backend
       area: asset.area,
-      type: asset.type || 'דירה',
+      type: determineAssetType(asset),
       status: asset.status || 'active',
       images: asset.images || [],
       description: asset.description || '',
@@ -85,7 +89,7 @@ export async function POST(req: Request) {
       bedrooms: 0,
       bathrooms: 1,
       area: 0,
-      type: 'דירה',
+      type: determineAssetType(body),
       status: 'pending',
       images: [],
       description: `נכס ${validatedData.scope.type} - ${validatedData.city}`,

--- a/realestate-broker-ui/app/api/sync/route.ts
+++ b/realestate-broker-ui/app/api/sync/route.ts
@@ -13,7 +13,7 @@ async function collectDataFromSources(address: string) {
     bedrooms: Math.floor(Math.random() * 3) + 2, // 2-4 rooms
     bathrooms: Math.floor(Math.random() * 2) + 1, // 1-2 bathrooms
     area: Math.floor(Math.random() * 50) + 60, // 60-110 sqm
-    type: 'דירה',
+    type: 'לא ידוע',
     
     // GIS data
     zoning: 'מגורים א\'',


### PR DESCRIPTION
## Summary
- Derive asset type from available fields and default to `לא ידוע`
- Update asset detail endpoint to use new asset type detection
- Replace hard-coded apartment defaults and adjust tests

## Testing
- `cd realestate-broker-ui && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68afb2c0d2608328aa286c02c5733db1