### PR TITLE
fix: restore zoom control after form usage

### DIFF
--- a/realestate-broker-ui/app/globals.css
+++ b/realestate-broker-ui/app/globals.css
@@ -99,7 +99,7 @@
   * {
     @apply border-border;
     /* Ensure proper touch behavior on mobile */
-    touch-action: pan-y;
+    touch-action: pan-y pinch-zoom;
   }
   body {
     @apply bg-background text-foreground;
@@ -108,7 +108,7 @@
     -webkit-overflow-scrolling: touch;
     overscroll-behavior: none;
     /* Prevent mobile zoom issues */
-    touch-action: pan-y;
+    touch-action: pan-y pinch-zoom;
   }
   
   /* Mobile-specific scrolling improvements */
@@ -122,7 +122,7 @@
     main {
       -webkit-overflow-scrolling: touch;
       overscroll-behavior: contain;
-      touch-action: pan-y;
+      touch-action: pan-y pinch-zoom;
     }
     
     /* Ensure the main content wrapper is properly sized */
@@ -163,13 +163,13 @@
     
     /* Ensure mobile sidebar works properly */
     [data-radix-dialog-content] {
-      touch-action: pan-y;
+      touch-action: pan-y pinch-zoom;
       -webkit-overflow-scrolling: touch;
     }
     
     /* Mobile sidebar specific styles */
     .mobile-sidebar {
-      touch-action: pan-y;
+      touch-action: pan-y pinch-zoom;
       -webkit-overflow-scrolling: touch;
     }
     
@@ -181,7 +181,7 @@
     
     /* Mobile sidebar touch improvements */
     .mobile-sidebar-nav {
-      touch-action: pan-y;
+      touch-action: pan-y pinch-zoom;
       -webkit-overflow-scrolling: touch;
     }
     

--- a/realestate-broker-ui/app/layout.tsx
+++ b/realestate-broker-ui/app/layout.tsx
@@ -13,7 +13,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="he" dir="rtl" suppressHydrationWarning>
       <head>
-        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
         <link rel="icon" href="/brand/favicon.svg" type="image/svg+xml" />
         <link rel="alternate icon" href="/brand/favicon-32.png" sizes="32x32" />
         <link rel="apple-touch-icon" href="/brand/favicon-192.png" />

--- a/realestate-broker-ui/components/ui/command.tsx
+++ b/realestate-broker-ui/components/ui/command.tsx
@@ -46,7 +46,7 @@ const CommandInput = React.forwardRef<
     <CommandPrimitive.Input
       ref={ref}
       className={cn(
-        "flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+        "flex h-11 w-full rounded-md bg-transparent py-3 text-base outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}

--- a/realestate-broker-ui/components/ui/input.tsx
+++ b/realestate-broker-ui/components/ui/input.tsx
@@ -11,7 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/realestate-broker-ui/components/ui/select.tsx
+++ b/realestate-broker-ui/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- allow users to zoom by removing viewport scaling restriction
- ensure form controls use 16px fonts to prevent auto zoom
- permit pinch gestures in mobile styles

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afb5334e048328aaf1830a63113987