### PR TITLE
Fix settings save endpoint path

### DIFF
--- a/realestate-broker-ui/app/settings/page.tsx
+++ b/realestate-broker-ui/app/settings/page.tsx
@@ -37,7 +37,7 @@ export default function SettingsPage() {
   useEffect(() => {
     const load = async () => {
       try {
-        const res = await fetch('/api/settings/')
+        const res = await fetch('/api/settings')
         if (res.ok) {
           const data = await res.json()
           setSettings(data)
@@ -51,7 +51,7 @@ export default function SettingsPage() {
 
   const handleSave = async () => {
     try {
-      const res = await fetch('/api/settings/', {
+      const res = await fetch('/api/settings', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(settings)


### PR DESCRIPTION
## Summary
- fix settings API calls to omit trailing slash and match Next.js route

## Testing
- `npm test -- --run`
- `pytest -q` *(fails: HTTPSConnectionPool host proxy errors)*

------
https://chatgpt.com/codex/tasks/task_e_68afd64f059c832894ad1dd8966977e7