### PR TITLE
Fix report generation fallback when backend misses asset

### DIFF
--- a/realestate-broker-ui/app/api/reports/route.test.ts
+++ b/realestate-broker-ui/app/api/reports/route.test.ts
@@ -100,6 +100,26 @@ describe('reports API', () => {
     expect(data.error).toBe('Invalid assetId');
   });
 
+  it('falls back to local data when backend returns 404', async () => {
+    const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValueOnce(
+      new Response('Not found', { status: 404 })
+    );
+
+    const req = new Request('http://localhost/api/reports', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ assetId: assets[0].id }),
+    });
+
+    const res = await POST(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(data.report.assetId).toBe(assets[0].id);
+
+    fetchMock.mockRestore();
+  });
+
   it('lists reports', async () => {
     const res = await GET(new Request('http://localhost/api/reports'));
     const data = await res.json();


### PR DESCRIPTION
## Summary
- fall back to mock asset data when backend report generation returns 404
- write reports to project-relative path for portability
- test report generation when backend returns 404

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0f65fdae88328aa908fbf100a188b