### PR TITLE
Open report PDF from report table

### DIFF
--- a/realestate-broker-ui/app/reports/page.test.tsx
+++ b/realestate-broker-ui/app/reports/page.test.tsx
@@ -29,7 +29,8 @@ describe('ReportsPage', () => {
     // Wait for the report address to appear in the main link
     const reportLink = await screen.findByRole('link', { name: 'Demo St 1' });
     expect(reportLink).toBeInTheDocument();
-    expect(reportLink).toHaveAttribute('href', '/assets/1');
+    expect(reportLink).toHaveAttribute('href', '/reports/r1.pdf');
+    expect(reportLink).toHaveAttribute('target', '_blank');
     
     // Verify the API was called
     expect(fetchMock).toHaveBeenCalledWith('/api/reports');

--- a/realestate-broker-ui/app/reports/page.tsx
+++ b/realestate-broker-ui/app/reports/page.tsx
@@ -158,8 +158,9 @@ export default function ReportsPage() {
                             <TableCell>
                               <div>
                                 <div className="font-semibold">
-                                  <Link 
-                                    href={`/assets/${report.assetId}`}
+                                  <Link
+                                    href={`/reports/${report.filename}`}
+                                    target="_blank"
                                     className="hover:text-primary transition-colors"
                                   >
                                     {report.address}
@@ -167,7 +168,7 @@ export default function ReportsPage() {
                                 </div>
                                 <div className="text-xs text-muted-foreground flex items-center gap-1">
                                   <MapPin className="h-3 w-3" />
-                                  <span>פרטי הנכס</span>
+                                  <span>צפה בדוח</span>
                                 </div>
                               </div>
                             </TableCell>


### PR DESCRIPTION
## Summary
- open report instead of asset details when clicking report address
- update report page test to expect report PDF link

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0f6dc5a748328a41f0f4cc61332bc