### PR TITLE
Display actual asset type in listings

### DIFF
--- a/realestate-broker-ui/app/assets/[id]/page.tsx
+++ b/realestate-broker-ui/app/assets/[id]/page.tsx
@@ -186,8 +186,7 @@ export default function AssetDetail({ params }: { params: { id: string } }) {
             <div>
               <h1 className="text-3xl font-bold">{asset.address}</h1>
               <p className="text-muted-foreground">
-                {asset.city}{asset.neighborhood ? ` · ${asset.neighborhood}` : ''} ·
-                {asset.type === 'house' ? ' בית' : ' דירה'} · {asset.netSqm} מ״ר נטו
+                {asset.city}{asset.neighborhood ? ` · ${asset.neighborhood}` : ''} · {asset.type ?? '—'} · {asset.netSqm} מ״ר נטו
               </p>
             </div>
           </div>
@@ -335,7 +334,7 @@ export default function AssetDetail({ params }: { params: { id: string } }) {
                 <CardContent className="space-y-2">
                   <div className="flex justify-between rtl:flex-row-reverse">
                     <span className="text-muted-foreground">סוג:</span>
-                    <span>{asset.type === 'house' ? 'בית' : 'דירה'}</span>
+                    <span>{asset.type ?? '—'}</span>
                   </div>
                   <div className="flex justify-between rtl:flex-row-reverse">
                     <span className="text-muted-foreground">מ״ר נטו:</span>

--- a/realestate-broker-ui/components/AssetsTable.tsx
+++ b/realestate-broker-ui/components/AssetsTable.tsx
@@ -23,7 +23,7 @@ const columns: ColumnDef<Asset>[] = [
           <Link href={`/assets/${row.original.id}`}>{row.original.address}</Link>
         </div>
         <div className="text-xs text-sub">
-          {row.original.city}{row.original.neighborhood?` · ${row.original.neighborhood}`:''} · {row.original.type==='house'?'בית':'דירה'} · {row.original.netSqm??'—'} מ&quot;ר נטו
+            {row.original.city}{row.original.neighborhood?` · ${row.original.neighborhood}`:''} · {row.original.type ?? '—'} · {row.original.netSqm??'—'} מ&quot;ר נטו
         </div>
       </div>
     ) 

--- a/realestate-broker-ui/lib/utils.test.ts
+++ b/realestate-broker-ui/lib/utils.test.ts
@@ -142,4 +142,5 @@ describe('Utils', () => {
       expect(fmtPct(250.75)).toBe('+250.8%')
     })
   })
+
 })


### PR DESCRIPTION
## Summary
- remove `fmtAssetType` helper and its tests
- display provided `type` string in assets table and detail page

## Testing
- `npm test`
- `npm run lint`
- `pytest` *(fails: ProxyError, assert False, AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f53ed134832881f2d97883773c05