### PR TITLE
Fix Hebrew report text rendering

### DIFF
--- a/backend-django/requirements.txt
+++ b/backend-django/requirements.txt
@@ -39,3 +39,4 @@ gunicorn>=20.1.0
 # Optional: PDF Generation (uncomment if needed)
 reportlab>=3.6.0
 PyPDF2>=2.0.0
+python-bidi>=0.4.2


### PR DESCRIPTION
## Summary
- ensure PDF report uses right-to-left Hebrew text and translations
- add python-bidi dependency for proper Hebrew rendering

## Testing
- `pytest` *(fails: requests.exceptions.ProxyError, assert False)*

------
https://chatgpt.com/codex/tasks/task_e_68b1060a13508328ab73fbac25da456f