### PR TITLE
Remove GIS offline fallbacks from production

### DIFF
--- a/gis/gis_client.py
+++ b/gis/gis_client.py
@@ -22,7 +22,6 @@ import re
 import time
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
-from pathlib import Path
 
 import requests
 from bs4 import BeautifulSoup
@@ -101,11 +100,6 @@ class TelAvivGS:
                     time.sleep(0.8 * (attempt + 1))
                     continue
                 self._logger.error("ArcGIS request failed", extra={"error": str(e)})
-                # Offline fallback for tests when network is unavailable
-                if layer == self.L_BLOCKS:
-                    return {"features": [{"attributes": {"ms_gush": "6638"}}]}
-                if layer == self.L_PARCELS:
-                    return {"features": [{"attributes": {"ms_chelka": "96"}}]}
                 raise
 
     def get_address_coordinates(self, street: str, house_number: int, like: bool = True) -> Tuple[float, float]:
@@ -271,24 +265,8 @@ class TelAvivGS:
             self._logger.info(
                 "Downloading privilege page", extra={"url": privilege_url, "gush": gush, "helka": helka}
             )
-            try:
-                r = requests.get(privilege_url, headers=self.HDRS, timeout=30, allow_redirects=True)
-                r.raise_for_status()
-            except requests.RequestException:
-                # Fallback to bundled sample file when network is unavailable
-                sample = Path(__file__).resolve().parents[1] / "tests" / "gis" / "test_privilege_pages" / f"privilege_gush_{gush}_helka_{helka}.pdf"
-                if sample.exists():
-                    parsed_pdf = parse_zchuyot(str(sample))
-                    return {
-                        "file_path": str(sample),
-                        "content_type": "pdf",
-                        "gush": gush,
-                        "helka": helka,
-                        "parcels": [],
-                        "pdf_data": [{"file_path": str(sample), "data": parsed_pdf}],
-                        "message": "Offline sample used",
-                    }
-                raise
+            r = requests.get(privilege_url, headers=self.HDRS, timeout=30, allow_redirects=True)
+            r.raise_for_status()
             
             # Detect content type
             content_type = r.headers.get("Content-Type", "").lower()


### PR DESCRIPTION
## Summary
- remove hardcoded offline responses from TelAvivGS client
- mock GIS network calls directly in tests

## Testing
- `pytest tests/gis/test_gis_client.py tests/gis/test_privilege_page.py`


------
https://chatgpt.com/codex/tasks/task_e_68b11476324c8328ae740e794b37efd1