### PR TITLE
Fix report generation spinner and redirection

### DIFF
--- a/realestate-broker-ui/app/assets/[id]/page.tsx
+++ b/realestate-broker-ui/app/assets/[id]/page.tsx
@@ -103,19 +103,27 @@ export default function AssetDetail({ params }: { params: { id: string } }) {
 
   const handleGenerateReport = async () => {
     if (!id) return
+
     setGeneratingReport(true)
+
     try {
       const res = await fetch('/api/reports', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ assetId: Number(id) })
       })
-      if (res.ok) {
-        router.push('/reports')
+
+      if (!res.ok) {
+        console.error('Report generation failed:', await res.text())
+        return
       }
+
+      // stop loading state before navigating to ensure the
+      // "generating" indicator doesn't remain stuck
+      setGeneratingReport(false)
+      router.push('/reports')
     } catch (err) {
       console.error('Report generation failed:', err)
-    } finally {
       setGeneratingReport(false)
     }
   }

--- a/tests/core/tests_reports_pdf.py
+++ b/tests/core/tests_reports_pdf.py
@@ -35,7 +35,7 @@ class HebrewPDFGenerationTest(TestCase):
         resp = views.reports(req)
         self.assertEqual(resp.status_code, 201, resp.content)
 
-        filename = resp.json()["report"]["filename"]
+        filename = json.loads(resp.content)["report"]["filename"]
         path = os.path.join(self.tmpdir, filename)
         self.assertTrue(os.path.exists(path), f"ציפינו לקובץ PDF בנתיב {path}")
 


### PR DESCRIPTION
## Summary
- ensure report generation spinner clears before navigation
- log failed report generation responses
- decode JsonResponse in PDF generation test using `json.loads`

## Testing
- `npm test -- --run app/assets/[id]/page.test.tsx`
- `pytest tests/core/tests_reports_pdf.py`


------
https://chatgpt.com/codex/tasks/task_e_68b28cd4a9288328bf58fb7220eaffd9