### PR TITLE
Ensure report URLs point to generated files

### DIFF
--- a/backend-django/core/models.py
+++ b/backend-django/core/models.py
@@ -197,8 +197,17 @@ class Report(models.Model):
     
     @property
     def file_url(self):
-        """Return the URL to access the report file."""
-        return f"/media/reports/{self.filename}"
+        """Return the URL to access the report file.
+
+        Reports are stored in the front-end ``public/reports`` directory which
+        is served directly at ``/reports``.  The previous implementation
+        returned a URL under ``/media`` which does not exist in the Next.js
+        application, causing generated reports to return 404 when users tried
+        to open them.  By pointing to ``/reports`` we align the URL with the
+        actual file location.
+        """
+
+        return f"/reports/{self.filename}"
     
     def mark_completed(self, file_size=None, pages=None, generation_time=None):
         """Mark the report as completed with metadata."""

--- a/tests/core/tests_reports_pdf.py
+++ b/tests/core/tests_reports_pdf.py
@@ -7,6 +7,7 @@ from django.test import TestCase, RequestFactory
 from pypdf import PdfReader
 
 from core import views
+from core.models import Report
 
 class HebrewPDFGenerationTest(TestCase):
     def setUp(self):
@@ -38,6 +39,11 @@ class HebrewPDFGenerationTest(TestCase):
         filename = json.loads(resp.content)["report"]["filename"]
         path = os.path.join(self.tmpdir, filename)
         self.assertTrue(os.path.exists(path), f"ציפינו לקובץ PDF בנתיב {path}")
+
+        # Verify the Report model points to the correct URL and path
+        report = Report.objects.get(filename=filename)
+        self.assertEqual(report.file_path, path)
+        self.assertEqual(report.file_url, f"/reports/{filename}")
 
         # Extract text and verify Hebrew section titles exist
         reader = PdfReader(path)


### PR DESCRIPTION
## Summary
- fix report model to generate `/reports/...` URLs instead of nonexistent `/media` path
- test report generation stores files and exposes correct path

## Testing
- `pytest tests/core/tests_reports_pdf.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2c44a4ddc8328beda0ad1ac22615c