### PR TITLE
Ensure report URLs point to generated files

### DIFF
--- a/backend-django/core/models.py
+++ b/backend-django/core/models.py
@@ -197,8 +197,17 @@ class Report(models.Model):
     
     @property
     def file_url(self):
-        """Return the URL to access the report file."""
-        return f"/media/reports/{self.filename}"
+        """Return the URL to access the report file.
+
+        Reports are stored in the front-end ``public/reports`` directory which
+        is served directly at ``/reports``.  The previous implementation
+        returned a URL under ``/media`` which does not exist in the Next.js
+        application, causing generated reports to return 404 when users tried
+        to open them.  By pointing to ``/reports`` we align the URL with the
+        actual file location.
+        """
+
+        return f"/reports/{self.filename}"
     
     def mark_completed(self, file_size=None, pages=None, generation_time=None):
         """Mark the report as completed with metadata."""

--- a/tests/core/tests_reports_pdf.py
+++ b/tests/core/tests_reports_pdf.py
@@ -7,12 +7,64 @@ from django.test import TestCase, RequestFactory
 from pypdf import PdfReader
 
 from core import views
+from core.models import Report, Asset
 
 class HebrewPDFGenerationTest(TestCase):
     def setUp(self):
         self.factory = RequestFactory()
         self.tmpdir = tempfile.mkdtemp(prefix="reports_test_")
         views.REPORTS_DIR = self.tmpdir
+
+        # Insert a mock asset into the database so the endpoint can fetch real
+        # data instead of relying solely on in-memory mocks.
+        self.asset = Asset.objects.create(
+            scope_type='address',
+            city='תל אביב',
+            neighborhood='מרכז העיר',
+            street='הרצל',
+            number=123,
+            status='ready',
+            normalized_address='רחוב הרצל 123, תל אביב',
+            meta={
+                'address': 'רחוב הרצל 123, תל אביב',
+                'city': 'תל אביב',
+                'neighborhood': 'מרכז העיר',
+                'type': 'דירה',
+                'price': 2850000,
+                'bedrooms': 3,
+                'bathrooms': 2,
+                'netSqm': 85,
+                'area': 85,
+                'pricePerSqm': 33529,
+                'remainingRightsSqm': 45,
+                'program': 'תמ״א 38',
+                'lastPermitQ': 'Q2/24',
+                'noiseLevel': 2,
+                'competition1km': 'בינוני',
+                'zoning': 'מגורים א׳',
+                'priceGapPct': -5.2,
+                'expectedPriceRange': '2.7M - 3.0M',
+                'modelPrice': 3000000,
+                'confidencePct': 85,
+                'capRatePct': 3.2,
+                'rentEstimate': 9500,
+                'riskFlags': [],
+                'features': ['מעלית', 'חניה', 'מרפסת', 'משופצת'],
+                'contactInfo': {
+                    'agent': 'יוסי כהן',
+                    'phone': '050-1234567',
+                    'email': 'yossi@example.com'
+                },
+                'documents': [
+                    {'name': 'נסח טאבו', 'type': 'tabu'},
+                    {'name': 'תשריט בית משותף', 'type': 'condo_plan'},
+                    {'name': 'היתר בנייה', 'type': 'permit'},
+                    {'name': 'זכויות בנייה', 'type': 'rights'},
+                    {'name': 'שומת מכרעת', 'type': 'appraisal_decisive'},
+                    {'name': 'שומת רמ״י', 'type': 'appraisal_rmi'},
+                ],
+            },
+        )
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir, ignore_errors=True)
@@ -26,10 +78,10 @@ class HebrewPDFGenerationTest(TestCase):
             "או הגדר REPORT_HEBREW_FONT_PATH ל-TTF שתומך בעברית."
         )
 
-        # Generate report for mock assetId=1
+        # Generate report for the asset inserted into the test database
         req = self.factory.post(
             "/api/reports",
-            data=json.dumps({"assetId": 1}),
+            data=json.dumps({"assetId": self.asset.id}),
             content_type="application/json",
         )
         resp = views.reports(req)
@@ -38,6 +90,12 @@ class HebrewPDFGenerationTest(TestCase):
         filename = json.loads(resp.content)["report"]["filename"]
         path = os.path.join(self.tmpdir, filename)
         self.assertTrue(os.path.exists(path), f"ציפינו לקובץ PDF בנתיב {path}")
+
+        # Verify the Report model points to the correct URL and path
+        report = Report.objects.get(filename=filename)
+        self.assertEqual(report.file_path, path)
+        self.assertEqual(report.file_url, f"/reports/{filename}")
+        self.assertEqual(report.asset_id, self.asset.id)
 
         # Extract text and verify Hebrew section titles exist
         reader = PdfReader(path)
@@ -69,3 +127,25 @@ class HebrewPDFGenerationTest(TestCase):
             f"הכותרות העבריות הבאות לא נמצאו בטקסט: {missing}\n"
             f"תחילת הטקסט שהופק: {extracted[:350]!r}"
         )
+
+        # Ensure asset-specific data from the database made it into the PDF
+        self.assertIn('רחוב הרצל', extracted)
+
+    def test_unknown_asset_id_generates_placeholder_report(self):
+        """Ensure report generation succeeds even for unknown asset IDs."""
+        req = self.factory.post(
+            "/api/reports",
+            data=json.dumps({"assetId": 999}),
+            content_type="application/json",
+        )
+        resp = views.reports(req)
+        self.assertEqual(resp.status_code, 201, resp.content)
+
+        data = json.loads(resp.content)
+        filename = data["report"]["filename"]
+        path = os.path.join(self.tmpdir, filename)
+        self.assertTrue(os.path.exists(path), f"ציפינו לקובץ PDF בנתיב {path}")
+
+        report = Report.objects.get(filename=filename)
+        self.assertEqual(report.file_url, f"/reports/{filename}")
+        self.assertIsNone(report.asset_id)


### PR DESCRIPTION
## Summary
- fix report model to generate `/reports/...` URLs instead of nonexistent `/media` path
- test report generation stores files and exposes correct path
- generate placeholder report data for unknown asset IDs so API no longer returns 404
- load real asset data from the database before falling back to placeholders
- link generated reports to their asset records and seed tests with DB assets

## Testing
- `pytest tests/core/tests_reports_pdf.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2c44a4ddc8328beda0ad1ac22615c