### PR TITLE
Fix settings save by correctly forwarding JSON

### DIFF
--- a/realestate-broker-ui/app/api/settings/route.test.ts
+++ b/realestate-broker-ui/app/api/settings/route.test.ts
@@ -47,9 +47,13 @@ describe('/api/settings', () => {
       body: JSON.stringify({ language: 'he' })
     })
     const res = await PUT(req)
-    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('/api/settings/'), expect.objectContaining({
-      method: 'PUT'
-    }))
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/api/settings/'),
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({ language: 'he' })
+      })
+    )
     const data = await res.json()
     expect(data).toEqual({ success: true })
   })

--- a/realestate-broker-ui/app/api/settings/route.ts
+++ b/realestate-broker-ui/app/api/settings/route.ts
@@ -21,15 +21,20 @@ export async function PUT(req: Request) {
   if (!token) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
+  let body
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
 
-  const body = await req.text()
   const res = await fetch(`${BACKEND_URL}/api/settings/`, {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${token}`
     },
-    body
+    body: JSON.stringify(body)
   })
   const data = await res.json().catch(() => ({}))
   return NextResponse.json(data, { status: res.status })


### PR DESCRIPTION
## Summary
- parse request JSON in /api/settings PUT handler and forward to backend
- add test to ensure body is sent when saving settings

## Testing
- `npm test -- --run`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b302573f5c83288130f660bb80a28e