### PR TITLE
Track enrichment status lifecycle

### DIFF
--- a/backend-django/core/management/commands/create_sample_assets.py
+++ b/backend-django/core/management/commands/create_sample_assets.py
@@ -14,7 +14,7 @@ class Command(BaseCommand):
                 'scope_type': 'neighborhood',
                 'city': 'תל אביב',
                 'neighborhood': 'רמת החייל',
-                'status': 'ready',
+                'status': 'done',
                 'meta': {
                     'scope': {'type': 'neighborhood', 'value': 'רמת החייל', 'city': 'תל אביב'},
                     'radius': 250
@@ -25,7 +25,7 @@ class Command(BaseCommand):
                 'city': 'תל אביב',
                 'street': 'הגולן',
                 'number': 32,
-                'status': 'ready',
+                'status': 'done',
                 'meta': {
                     'scope': {'type': 'address', 'value': 'הגולן 32, תל אביב', 'city': 'תל אביב'},
                     'radius': 150

--- a/backend-django/core/migrations/0016_asset_enrich_fields_status_update.py
+++ b/backend-django/core/migrations/0016_asset_enrich_fields_status_update.py
@@ -1,0 +1,47 @@
+from django.db import migrations, models
+
+
+def forwards(apps, schema_editor):
+    Asset = apps.get_model('core', 'Asset')
+    Asset.objects.filter(status='ready').update(status='done')
+    Asset.objects.filter(status='error').update(status='failed')
+
+
+def backwards(apps, schema_editor):
+    Asset = apps.get_model('core', 'Asset')
+    Asset.objects.filter(status='done').update(status='ready')
+    Asset.objects.filter(status='failed').update(status='error')
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('core', '0015_merge_20250905_0933'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='asset',
+            name='last_enriched_at',
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='asset',
+            name='last_enrich_error',
+            field=models.TextField(blank=True, null=True),
+        ),
+        migrations.RunPython(forwards, backwards),
+        migrations.AlterField(
+            model_name='asset',
+            name='status',
+            field=models.CharField(
+                choices=[
+                    ('pending', 'Pending'),
+                    ('enriching', 'Enriching'),
+                    ('done', 'Done'),
+                    ('failed', 'Failed'),
+                ],
+                default='pending',
+                max_length=20,
+            ),
+        ),
+    ]

--- a/backend-django/core/models.py
+++ b/backend-django/core/models.py
@@ -98,8 +98,8 @@ class Asset(models.Model):
     STATUS_CHOICES = [
         ("pending", "Pending"),
         ("enriching", "Enriching"),
-        ("ready", "Ready"),
-        ("error", "Error"),
+        ("done", "Done"),
+        ("failed", "Failed"),
     ]
 
     scope_type = models.CharField(max_length=50, choices=SCOPE_TYPE_CHOICES)
@@ -149,6 +149,8 @@ class Asset(models.Model):
     status = models.CharField(max_length=20, choices=STATUS_CHOICES, default="pending")
     is_demo = models.BooleanField(default=False)
     meta = models.JSONField(default=dict)
+    last_enriched_at = models.DateTimeField(blank=True, null=True)
+    last_enrich_error = models.TextField(blank=True, null=True)
     created_at = models.DateTimeField(auto_now_add=True)
 
     class Meta:

--- a/backend-django/core/views.py
+++ b/backend-django/core/views.py
@@ -365,7 +365,7 @@ def demo_start(request):
     for data in sample_assets:
         Asset.objects.create(
             **data,
-            status="ready",
+            status="done",
             is_demo=True,
             meta={"demo": True},
         )
@@ -988,7 +988,7 @@ def assets(request):
             # Update asset status to error
             try:
                 asset = Asset.objects.get(id=asset_id)
-                asset.status = "error"
+                asset.status = "failed"
                 asset.meta["error"] = str(e)
                 asset.save()
             except Exception as save_error:

--- a/realestate-broker-ui/components/AssetsTable.tsx
+++ b/realestate-broker-ui/components/AssetsTable.tsx
@@ -125,8 +125,8 @@ function createColumns(onDelete?: (id: number) => void, onExport?: (asset: Asset
   { header:'סטטוס נכס', accessorKey:'assetStatus', cell: info => {
     const status = info.getValue() as string
     if (!status) return <Badge variant="default">—</Badge>
-    const variant = status === 'ready' ? 'good' : status === 'error' ? 'bad' : 'warn'
-    const label = status === 'ready' ? 'מוכן' : status === 'error' ? 'שגיאה' : status === 'enriching' ? 'מתעשר' : 'ממתין'
+    const variant = status === 'done' ? 'good' : status === 'failed' ? 'bad' : 'warn'
+    const label = status === 'done' ? 'מוכן' : status === 'failed' ? 'שגיאה' : status === 'enriching' ? 'מתעשר' : 'ממתין'
     return <Badge variant={variant}>{label}</Badge>
   }},
   { header:'מחיר מודל', accessorKey:'modelPrice', cell: info => <span className="font-mono">{fmtCurrency(info.getValue() as number)}</span> },

--- a/realestate-broker-ui/lib/data.ts
+++ b/realestate-broker-ui/lib/data.ts
@@ -210,7 +210,7 @@ export const assets: Asset[] = [
     urbanRenewalPotential: 'תמ"א 38/2',
     bettermentLevy: 'היטל צפוי כ-50 אלף ₪',
     assetId: 1,
-    assetStatus: 'ready',
+    assetStatus: 'done',
     sources: ['yad2', 'gis_permit', 'gis_rights', 'tabu'],
     primarySource: 'yad2',
     _meta: {

--- a/tests/core/test_demo_mode.py
+++ b/tests/core/test_demo_mode.py
@@ -52,7 +52,7 @@ def test_cleanup_demo_data_removes_old_entries():
         password="x",
         is_demo=True,
     )
-    asset = Asset.objects.create(scope_type="address", city="A", is_demo=True, status="ready")
+    asset = Asset.objects.create(scope_type="address", city="A", is_demo=True, status="done")
     old = timezone.now() - timedelta(days=2)
     User.objects.filter(id=user.id).update(created_at=old)
     Asset.objects.filter(id=asset.id).update(created_at=old)

--- a/tests/core/test_reports_pdf.py
+++ b/tests/core/test_reports_pdf.py
@@ -24,7 +24,7 @@ class HebrewPDFGenerationTest(TestCase):
             neighborhood='מרכז העיר',
             street='הרצל',
             number=123,
-            status='ready',
+            status='done',
             normalized_address='רחוב הרצל 123, תל אביב',
             meta={
                 'address': 'רחוב הרצל 123, תל אביב',

--- a/tests/core/test_tasks_pipeline.py
+++ b/tests/core/test_tasks_pipeline.py
@@ -16,8 +16,9 @@ class DummyPipeline:
 
 
 def test_run_data_pipeline_task(monkeypatch):
-    asset = Asset(scope_type='address', city='City', street='Main', number=5)
+    asset = Asset(id=1, scope_type='address', city='City', street='Main', number=5)
     monkeypatch.setattr(Asset.objects, 'get', lambda id: asset)
+    monkeypatch.setattr(asset, 'save', lambda *args, **kwargs: None)
     dummy = DummyPipeline()
     
     # Mock the orchestration import at the module level where it's imported from

--- a/yad2/scheduler.py
+++ b/yad2/scheduler.py
@@ -64,7 +64,7 @@ def _store_assets(
                     scope_type='address',
                     street=item.address.split()[0] if item.address else None,
                     number=item.address.split()[-1] if item.address else None,
-                    status='ready',
+                    status='done',
                     meta={
                         'yad2_data': {
                             'listing_id': item.listing_id,


### PR DESCRIPTION
## Summary
- record asset enrichment progress with `pending → enriching → done/failed` status flow
- store `last_enriched_at` and `last_enrich_error` on assets
- surface new statuses in views, UI tables and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bd03f664a883289c85a5842108d05b