### PR TITLE
Show onboarding checklist after report generation

### DIFF
--- a/realestate-broker-ui/app/assets/[id]/page.tsx
+++ b/realestate-broker-ui/app/assets/[id]/page.tsx
@@ -185,7 +185,8 @@ export default function AssetDetail({ params }: { params: { id: string } }) {
         console.error('Report generation failed:', await res.text())
         return
       }
-
+      localStorage.removeItem('onboardingDismissed')
+      window.dispatchEvent(new Event('onboardingUpdate'))
       router.push('/reports')
     } catch (err) {
       console.error('Report generation failed:', err)

--- a/realestate-broker-ui/components/OnboardingChecklist.tsx
+++ b/realestate-broker-ui/components/OnboardingChecklist.tsx
@@ -31,6 +31,23 @@ export default function OnboardingChecklist() {
   }, [isAuthenticated])
 
   useEffect(() => {
+    const handleUpdate = () => {
+      if (!isAuthenticated) return
+      authAPI
+        .getOnboardingStatus()
+        .then(newStatus => {
+          setStatus(newStatus)
+          setDismissed(false)
+          localStorage.removeItem('onboardingDismissed')
+        })
+        .catch(err => console.error('Failed to load onboarding status', err))
+    }
+
+    window.addEventListener('onboardingUpdate', handleUpdate)
+    return () => window.removeEventListener('onboardingUpdate', handleUpdate)
+  }, [isAuthenticated])
+
+  useEffect(() => {
     if (status?.completed && !celebrated) {
       confetti({ spread: 70, origin: { y: 0.6 } })
       setCelebrated(true)


### PR DESCRIPTION
## Summary
- Refresh onboarding checklist when onboarding status updates
- Reset dismissal and trigger refresh after generating reports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd08dc096483289d1343976d6cbbb4