### PR TITLE
feat(api): return job id for asset creation

### DIFF
--- a/backend-django/core/views.py
+++ b/backend-django/core/views.py
@@ -981,8 +981,10 @@ def assets(request):
         _update_onboarding(user, "add_first_asset")
 
         # Enqueue Celery task if available
+        job_id = None
         try:
-            run_data_pipeline.delay(asset_id)
+            result = run_data_pipeline.delay(asset_id)
+            job_id = result.id
         except Exception as e:
             print(f"Failed to enqueue enrichment task: {e}")
             # Update asset status to error
@@ -998,6 +1000,7 @@ def assets(request):
             {
                 "id": asset_id,
                 "status": asset_data["status"],
+                "job_id": job_id,
                 "message": "Asset created successfully, enrichment pipeline started",
             },
             status=201,

--- a/tests/core/test_assets_endpoint_pipeline.py
+++ b/tests/core/test_assets_endpoint_pipeline.py
@@ -9,9 +9,11 @@ import pytest
 class DummyTask:
     def __init__(self):
         self.calls = []
+        self.job_id = "job-123"
 
     def delay(self, asset_id, max_pages=1):
         self.calls.append((asset_id, max_pages))
+        return type("AsyncResult", (), {"id": self.job_id})()
 
 
 def test_assets_post_triggers_pipeline(monkeypatch):
@@ -37,6 +39,8 @@ def test_assets_post_triggers_pipeline(monkeypatch):
     assert response.status_code == 201
     # Ensure the Celery task was called with the new asset ID
     assert dummy.calls == [(dummy_asset.id, 1)]
+    data = json.loads(response.content)
+    assert data["job_id"] == dummy.job_id
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- include Celery job_id in POST /api/assets/ responses for enrichment tracking
- verify job_id return in asset pipeline tests

## Testing
- `pytest tests/core/test_assets_endpoint_pipeline.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd14fcb4408328adcb2ccea0ac2734