### PR TITLE
feat: add structured collector logging

### DIFF
--- a/backend-django/core/tasks.py
+++ b/backend-django/core/tasks.py
@@ -45,7 +45,7 @@ def run_data_pipeline(asset_id: int, max_pages: int = 1):
     house_number = asset.number or 0
     logger.info("Starting data pipeline for asset %s", asset_id)
     try:
-        result = pipeline.run(address, house_number, max_pages=max_pages)
+        result = pipeline.run(address, house_number, max_pages=max_pages, asset_id=asset_id)
         track('asset_sync', asset_id=asset_id)
         asset.status = "done"
         asset.last_enriched_at = timezone.now()

--- a/tests/core/test_data_pipeline.py
+++ b/tests/core/test_data_pipeline.py
@@ -102,7 +102,7 @@ def test_data_pipeline_integration():
     )
 
     # Run the pipeline - it should return collected data, not save to database
-    results = pipeline.run("Fake", 1)
+    results = pipeline.run("Fake", 1, asset_id=123)
     
     # Verify that the pipeline returned results
     assert results, "Pipeline did not return any results"

--- a/tests/core/test_tasks_pipeline.py
+++ b/tests/core/test_tasks_pipeline.py
@@ -10,8 +10,8 @@ class DummyPipeline:
     def __init__(self):
         self.calls = []
 
-    def run(self, address, number, max_pages=1):
-        self.calls.append((address, number, max_pages))
+    def run(self, address, number, max_pages=1, asset_id=None):
+        self.calls.append((address, number, max_pages, asset_id))
         return [42]
 
 
@@ -26,4 +26,4 @@ def test_run_data_pipeline_task(monkeypatch):
         result = tasks.run_data_pipeline.run(1)
 
     assert result == [42]
-    assert dummy.calls == [('Main', 5, 1)]
+    assert dummy.calls == [('Main', 5, 1, 1)]

--- a/tests/orchestration/test_pipeline_alerts.py
+++ b/tests/orchestration/test_pipeline_alerts.py
@@ -88,6 +88,6 @@ def test_pipeline_sends_alerts(monkeypatch):
     notifier = DummyNotifier()
     monkeypatch.setattr(data_pipeline, "_load_user_notifiers", lambda: [notifier])
 
-    pipeline.run("Fake", 1)
+    pipeline.run("Fake", 1, asset_id=123)
 
     assert notifier.calls == ["t"]


### PR DESCRIPTION
## Summary
- add structured logging for collectors with asset context
- propagate asset_id through pipeline and task
- adjust tests for new logging flow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd153c9a4c8328a251ef3f72200d47