### PR TITLE
Add per-field provenance metadata

### DIFF
--- a/backend-django/core/serializers.py
+++ b/backend-django/core/serializers.py
@@ -24,11 +24,48 @@ class MetaSerializerMixin(serializers.ModelSerializer):
 
 
 class AssetSerializer(MetaSerializerMixin):
+    size = serializers.SerializerMethodField()
+    rights = serializers.SerializerMethodField()
+    permits = serializers.SerializerMethodField()
+    comps = serializers.SerializerMethodField()
+
+    KEY_FIELDS = ["city", "size", "rights", "permits", "comps"]
+
+    def _get_meta_value(self, obj, field):
+        meta = getattr(obj, "meta", {}) or {}
+        value = meta.get(field)
+        if isinstance(value, dict):
+            return value.get("value")
+        return None
+
+    def get_size(self, obj):
+        return self._get_meta_value(obj, "size")
+
+    def get_rights(self, obj):
+        return self._get_meta_value(obj, "rights")
+
+    def get_permits(self, obj):
+        return self._get_meta_value(obj, "permits")
+
+    def get_comps(self, obj):
+        return self._get_meta_value(obj, "comps")
+
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        # Override key field values from meta if provided
+        meta = getattr(instance, "meta", {}) or {}
+        for field in self.KEY_FIELDS:
+            meta_val = meta.get(field)
+            if isinstance(meta_val, dict) and meta_val.get("value") is not None:
+                data[field] = meta_val["value"]
+        return data
+
     class Meta:
         model = Asset
         fields = [
             'id', 'scope_type', 'city', 'neighborhood', 'street', 'number',
-            'gush', 'helka', 'lat', 'lon', 'normalized_address', 'status'
+            'gush', 'helka', 'lat', 'lon', 'normalized_address', 'status',
+            'size', 'rights', 'permits', 'comps'
         ]
 
 

--- a/tests/core/test_serializers_meta.py
+++ b/tests/core/test_serializers_meta.py
@@ -4,13 +4,61 @@ from core.serializers import AssetSerializer
 
 def test_asset_serializer_meta_multiple_sources():
     asset = Asset(
-        city="תל אביב",
-        price=1000000,
         meta={
-            "city": {"source": "מנהל התכנון", "fetched_at": "2025-09-01", "url": "http://example.com/city"},
-            "price": {"source": "yad2", "fetched_at": "2025-08-20", "url": "http://example.com/price"},
+            "city": {
+                "value": "תל אביב",
+                "source": "מנהל התכנון",
+                "fetched_at": "2025-09-01",
+                "url": "http://example.com/city",
+            },
+            "size": {
+                "value": 80,
+                "source": "yad2",
+                "fetched_at": "2025-08-20",
+            },
+            "rights": {
+                "value": {"extra": 1},
+                "source": "gis_rights",
+                "fetched_at": "2025-08-21",
+            },
+            "permits": {
+                "value": [{"permit": "p"}],
+                "source": "gis_permit",
+                "fetched_at": "2025-08-22",
+                "url": "http://example.com/permits",
+            },
+            "comps": {
+                "value": [{"price": 1_000_000}],
+                "source": "gov",
+                "fetched_at": "2025-08-23",
+            },
         },
     )
     data = AssetSerializer(asset).data
-    assert data["_meta"]["city"] == {"source": "מנהל התכנון", "fetched_at": "2025-09-01", "url": "http://example.com/city"}
-    assert data["_meta"]["price"] == {"source": "yad2", "fetched_at": "2025-08-20", "url": "http://example.com/price"}
+    assert data["city"] == "תל אביב"
+    assert data["size"] == 80
+    assert data["rights"] == {"extra": 1}
+    assert data["permits"] == [{"permit": "p"}]
+    assert data["comps"] == [{"price": 1_000_000}]
+    assert data["_meta"]["city"] == {
+        "source": "מנהל התכנון",
+        "fetched_at": "2025-09-01",
+        "url": "http://example.com/city",
+    }
+    assert data["_meta"]["size"] == {
+        "source": "yad2",
+        "fetched_at": "2025-08-20",
+    }
+    assert data["_meta"]["rights"] == {
+        "source": "gis_rights",
+        "fetched_at": "2025-08-21",
+    }
+    assert data["_meta"]["permits"] == {
+        "source": "gis_permit",
+        "fetched_at": "2025-08-22",
+        "url": "http://example.com/permits",
+    }
+    assert data["_meta"]["comps"] == {
+        "source": "gov",
+        "fetched_at": "2025-08-23",
+    }

--- a/yad2/scrapers/yad2_scraper.py
+++ b/yad2/scrapers/yad2_scraper.py
@@ -166,10 +166,18 @@ class Yad2Scraper:
 
             if listing.url:
                 listing.meta['price'] = {
+                    'value': listing.price,
                     'source': 'yad2',
                     'fetched_at': meta_time,
                     'url': listing.url,
                 }
+                if listing.size:
+                    listing.meta['size'] = {
+                        'value': listing.size,
+                        'source': 'yad2',
+                        'fetched_at': meta_time,
+                        'url': listing.url,
+                    }
             
             return listing
             


### PR DESCRIPTION
## Summary
- emit field-level provenance in `AssetSerializer`
- include `value` in Yad2 listing metadata for price and size
- test serializer output for key fields and provenance

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd14634ce083288cd4b5f8d0e23eb4