### PR TITLE
refactor: remove mock fallbacks and unify asset normalizer

### DIFF
--- a/realestate-broker-ui/app/api/assets/[id]/route.ts
+++ b/realestate-broker-ui/app/api/assets/[id]/route.ts
@@ -1,9 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { assets } from '@/lib/data'
-
-function determineAssetType(asset: any): string {
-  return asset?.propertyType || asset?.property_type || asset?.type || 'לא ידוע'
-}
+import { normalizeFromBackend } from '@/lib/normalizers/asset'
 
 export async function GET(
   request: NextRequest,
@@ -25,72 +21,7 @@ export async function GET(
         : data
 
       if (backendAsset) {
-        const asset: any = {
-          id: Number(backendAsset.id ?? backendAsset['external_id']),
-          address: backendAsset.address,
-          price: backendAsset.price,
-          bedrooms: backendAsset.rooms || 3,
-          bathrooms: backendAsset.bathrooms || 2,
-          area: backendAsset.size || 85,
-          type: determineAssetType(backendAsset),
-          status: 'active',
-          images: backendAsset.images || ['/placeholder-home.jpg'],
-          description: backendAsset.description || 'תיאור הנכס',
-          features: backendAsset.features || ['מעלית', 'חניה'],
-          contactInfo: backendAsset['contact_info'] || {
-            name: 'משרד תיווך',
-            phone: '03-1234567',
-            email: 'info@broker.co.il'
-          },
-          // Additional fields for detailed view
-          city: backendAsset.address?.split(',')[1]?.trim() || 'תל אביב',
-          neighborhood: backendAsset.address?.split(',')[2]?.trim() || 'מרכז העיר',
-          netSqm: backendAsset.size || 85,
-          pricePerSqmDisplay: backendAsset.price && backendAsset.size ?
-            Math.round(backendAsset.price / backendAsset.size) : 29412,
-          // Financial analysis
-          expectedPriceRange: backendAsset.price ?
-            `${(backendAsset.price * 0.9 / 1000000).toFixed(1)}M - ${(backendAsset.price * 1.1 / 1000000).toFixed(1)}M` :
-            '₪2.7M - ₪3.3M',
-          confidencePct: 85,
-          capRatePct: 3.2,
-          priceGapPct: -5.2,
-          competition1km: 12,
-          // Rights and permits
-          remainingRightsSqm: 45,
-          zoning: 'מגורים',
-          program: 'תכנית מפורטת 5000',
-          lastPermitQ: 'Q4/23',
-          // Environmental factors
-          noiseLevel: 2,
-          greenWithin300m: true,
-          antennaDistanceM: 150,
-          riskFlags: ['שימור מבנה'],
-          // Model and estimates
-          modelPrice: backendAsset.price || 3000000,
-          rentEstimate: backendAsset.price ? Math.round(backendAsset.price * 0.004) : 9500,
-          permitDate: backendAsset['permit_date'],
-          permitStatus: backendAsset['permit_status'],
-          permitDetails: backendAsset['permit_details'],
-          permitMainArea: backendAsset['permit_main_area'],
-          permitServiceArea: backendAsset['permit_service_area'],
-          permitApplicant: backendAsset['permit_applicant'],
-          permitDocUrl: backendAsset['permit_doc_url'],
-          mainRightsSqm: backendAsset['main_rights_sqm'],
-          serviceRightsSqm: backendAsset['service_rights_sqm'],
-          additionalPlanRights: backendAsset['additional_plan_rights'],
-          planStatus: backendAsset['plan_status'],
-          publicObligations: backendAsset['public_obligations'],
-          publicTransport: backendAsset['public_transport'],
-          openSpacesNearby: backendAsset['open_spaces_nearby'],
-          publicBuildings: backendAsset['public_buildings'],
-          parking: backendAsset.parking,
-          nearbyProjects: backendAsset['nearby_projects'],
-          rightsUsagePct: backendAsset['rights_usage_pct'],
-          legalRestrictions: backendAsset['legal_restrictions'],
-          urbanRenewalPotential: backendAsset['urban_renewal_potential'],
-          bettermentLevy: backendAsset['betterment_levy']
-        }
+        const asset: any = normalizeFromBackend(backendAsset)
 
         const backendMeta = backendAsset._meta || backendAsset.meta || {}
         const meta: Record<string, any> = {}
@@ -106,9 +37,5 @@ export async function GET(
   } catch (error) {
     console.error('Error fetching asset from backend:', error)
   }
-
-  // Fallback to mock data
-  const asset = assets.find(l => l.id === Number(id))
-  if(!asset) return new NextResponse('Not found', { status: 404, statusText: 'Not Found' })
-  return NextResponse.json({ asset })
+  return new NextResponse('Not found', { status: 404, statusText: 'Not Found' })
 }

--- a/realestate-broker-ui/app/api/reports/route.ts
+++ b/realestate-broker-ui/app/api/reports/route.ts
@@ -199,7 +199,7 @@ export async function POST(req: Request) {
     doc.text(`Price: ₪${asset.price?.toLocaleString('he-IL') || 'N/A'}`, 20, y); y += 10;
     doc.text(`Bedrooms: ${asset.bedrooms || 'N/A'}`, 20, y); y += 10;
     doc.text(`Bathrooms: ${asset.bathrooms || 'N/A'}`, 20, y); y += 10;
-    doc.text(`Area: ${asset.netSqm || asset.area || 'N/A'} sqm`, 20, y); y += 10;
+    doc.text(`Area: ${asset.area ?? 'N/A'} sqm`, 20, y); y += 10;
     doc.text(`Price per sqm: ₪${asset.pricePerSqmDisplay?.toLocaleString('he-IL') || 'N/A'}`, 20, y); y += 10;
     
     // Financial Analysis Section
@@ -244,14 +244,14 @@ export async function POST(req: Request) {
     doc.text(`Current Plan: ${asset.program || 'N/A'}`, 20, y); y += 10;
     doc.text(`Zoning: ${asset.zoning || 'N/A'}`, 20, y); y += 10;
     doc.text(`Remaining Rights: +${asset.remainingRightsSqm || 'N/A'} sqm`, 20, y); y += 10;
-    doc.text(`Main Building Rights: ${asset.netSqm || asset.area || 'N/A'} sqm`, 20, y); y += 10;
+    doc.text(`Main Building Rights: ${asset.area ?? 'N/A'} sqm`, 20, y); y += 10;
     
     y += 20;
     doc.setFontSize(14);
     doc.text('Building Rights Details', 20, y); y += 15;
     doc.setFontSize(12);
     doc.text(`Remaining Rights: ${asset.remainingRightsSqm || 'N/A'} sqm`, 20, y); y += 10;
-    const rightsPercentage = asset.remainingRightsSqm && asset.netSqm ? Math.round((asset.remainingRightsSqm / asset.netSqm) * 100) : 0;
+    const rightsPercentage = asset.remainingRightsSqm && asset.area ? Math.round((asset.remainingRightsSqm / asset.area) * 100) : 0;
     doc.text(`Additional Rights Percentage: ${rightsPercentage}%`, 20, y); y += 10;
     const rightsValue = asset.pricePerSqmDisplay && asset.remainingRightsSqm ? Math.round((asset.pricePerSqmDisplay * asset.remainingRightsSqm * 0.7) / 1000) : 0;
     doc.text(`Estimated Rights Value: ₪${rightsValue}K`, 20, y);

--- a/realestate-broker-ui/app/assets/[id]/page.test.tsx
+++ b/realestate-broker-ui/app/assets/[id]/page.test.tsx
@@ -30,7 +30,7 @@ describe('AssetDetailPage', () => {
             address: 'Test Street 1',
             city: 'Tel Aviv',
             type: 'house',
-            netSqm: 80,
+            area: 80,
             price: 1000000,
             pricePerSqm: 12500,
             documents: [],

--- a/realestate-broker-ui/app/assets/[id]/page.tsx
+++ b/realestate-broker-ui/app/assets/[id]/page.tsx
@@ -285,7 +285,7 @@ export default function AssetDetail({ params }: { params: { id: string } }) {
               <p className="text-muted-foreground">
                 {asset.city}
                 {asset.neighborhood ? ` · ${asset.neighborhood}` : ''} · {asset.type ?? '—'} ·{' '}
-                {formatNumber(asset.netSqm) ? `${formatNumber(asset.netSqm)} מ״ר נטו` : '—'}
+                {formatNumber(asset.area) ? `${formatNumber(asset.area)} מ״ר נטו` : '—'}
               </p>
             </div>
           </div>
@@ -522,15 +522,15 @@ export default function AssetDetail({ params }: { params: { id: string } }) {
                   </div>
                   <div className="flex justify-between rtl:flex-row-reverse">
                     <span className="text-muted-foreground">מ״ר נטו:</span>
-                    <span>{formatNumber(asset.netSqm) ?? '—'}</span>
+                    <span>{formatNumber(asset.area) ?? '—'}</span>
                   </div>
                   <div className="flex justify-between rtl:flex-row-reverse">
                     <span className="text-muted-foreground">חדרים:</span>
-                    <span>{asset.bedrooms || '—'}</span>
+                    <span>{asset.bedrooms ?? '—'}</span>
                   </div>
                   <div className="flex justify-between rtl:flex-row-reverse">
                     <span className="text-muted-foreground">ייעוד:</span>
-                    <span>{asset.zoning || '—'}</span>
+                    <span>{asset.zoning ?? '—'}</span>
                   </div>
                   <div className="flex justify-between rtl:flex-row-reverse">
                     <span className="text-muted-foreground">רמת ביטחון:</span>
@@ -568,7 +568,7 @@ export default function AssetDetail({ params }: { params: { id: string } }) {
                   </div>
                   <div className="flex justify-between rtl:flex-row-reverse">
                     <span className="text-muted-foreground">תחרות 1 ק״מ:</span>
-                    <span>{asset.competition1km || '—'}</span>
+                    <span>{asset.competition1km ?? '—'}</span>
                   </div>
                 </CardContent>
               </Card>
@@ -585,15 +585,15 @@ export default function AssetDetail({ params }: { params: { id: string } }) {
                 </div>
                 <div className="flex justify-between rtl:flex-row-reverse">
                   <span className="text-muted-foreground">מגבלות משפטיות:</span>
-                  <span>{asset.legalRestrictions || '—'}</span>
+                  <span>{asset.legalRestrictions ?? '—'}</span>
                 </div>
                 <div className="flex justify-between rtl:flex-row-reverse">
                   <span className="text-muted-foreground">פוטנציאל התחדשות:</span>
-                  <span>{asset.urbanRenewalPotential || '—'}</span>
+                  <span>{asset.urbanRenewalPotential ?? '—'}</span>
                 </div>
                 <div className="flex justify-between rtl:flex-row-reverse">
                   <span className="text-muted-foreground">היטל השבחה צפוי:</span>
-                  <span>{asset.bettermentLevy || '—'}</span>
+                  <span>{asset.bettermentLevy ?? '—'}</span>
                 </div>
               </CardContent>
             </Card>
@@ -658,11 +658,11 @@ export default function AssetDetail({ params }: { params: { id: string } }) {
                   <div className="space-y-2">
                     <div className="flex justify-between rtl:flex-row-reverse">
                       <span className="text-muted-foreground">תכנית נוכחית:</span>
-                      {renderValue(asset.program || 'לא זמין', 'program')}
+                      {renderValue(asset.program ?? 'לא זמין', 'program')}
                     </div>
                     <div className="flex justify-between rtl:flex-row-reverse">
                       <span className="text-muted-foreground">ייעוד:</span>
-                      {renderValue(<Badge variant="outline">{asset.zoning || 'לא צוין'}</Badge>, 'zoning')}
+                      {renderValue(<Badge variant="outline">{asset.zoning ?? 'לא צוין'}</Badge>, 'zoning')}
                     </div>
                     <div className="flex justify-between rtl:flex-row-reverse">
                       <span className="text-muted-foreground">יתרת זכויות:</span>
@@ -683,15 +683,15 @@ export default function AssetDetail({ params }: { params: { id: string } }) {
                     </div>
                     <div className="flex justify-between rtl:flex-row-reverse">
                       <span className="text-muted-foreground">זכויות משלימות:</span>
-                      {renderValue(asset.additionalPlanRights || 'אין', 'additionalPlanRights')}
+                      {renderValue(asset.additionalPlanRights ?? 'אין', 'additionalPlanRights')}
                     </div>
                     <div className="flex justify-between rtl:flex-row-reverse">
                       <span className="text-muted-foreground">מגבלות/חובות ציבוריות:</span>
-                      {renderValue(asset.publicObligations || 'אין', 'publicObligations')}
+                      {renderValue(asset.publicObligations ?? 'אין', 'publicObligations')}
                     </div>
                     <div className="flex justify-between rtl:flex-row-reverse">
                       <span className="text-muted-foreground">סטטוס תוכנית:</span>
-                      {renderValue(asset.planStatus || 'לא ידוע', 'planStatus')}
+                      {renderValue(asset.planStatus ?? 'לא ידוע', 'planStatus')}
                     </div>
                   </div>
                   <div className="pt-2 border-t">
@@ -738,8 +738,8 @@ export default function AssetDetail({ params }: { params: { id: string } }) {
                   </div>
                   <div className="text-center">
                     <div className="text-2xl font-bold">
-                      {asset.remainingRightsSqm !== undefined && asset.remainingRightsSqm !== null && asset.netSqm !== undefined && asset.netSqm !== null
-                        ? `${Math.round((asset.remainingRightsSqm / asset.netSqm) * 100)}%`
+                      {asset.remainingRightsSqm !== undefined && asset.remainingRightsSqm !== null && asset.area !== undefined && asset.area !== null
+                        ? `${Math.round((asset.remainingRightsSqm / asset.area) * 100)}%`
                         : '—'}
                     </div>
                     <div className="text-sm text-muted-foreground">אחוז זכויות נוספות</div>
@@ -816,23 +816,23 @@ export default function AssetDetail({ params }: { params: { id: string } }) {
               <CardContent className="space-y-2">
                 <div className="flex justify-between rtl:flex-row-reverse">
                   <span className="text-muted-foreground">תחבורה ציבורית:</span>
-                  {renderValue(asset.publicTransport || '—', 'publicTransport')}
+                  {renderValue(asset.publicTransport ?? '—', 'publicTransport')}
                 </div>
                 <div className="flex justify-between rtl:flex-row-reverse">
                   <span className="text-muted-foreground">שטחים פתוחים בקרבת מקום:</span>
-                  {renderValue(asset.openSpacesNearby || '—', 'openSpacesNearby')}
+                  {renderValue(asset.openSpacesNearby ?? '—', 'openSpacesNearby')}
                 </div>
                 <div className="flex justify-between rtl:flex-row-reverse">
                   <span className="text-muted-foreground">מבני ציבור:</span>
-                  {renderValue(asset.publicBuildings || '—', 'publicBuildings')}
+                  {renderValue(asset.publicBuildings ?? '—', 'publicBuildings')}
                 </div>
                 <div className="flex justify-between rtl:flex-row-reverse">
                   <span className="text-muted-foreground">מצב חניה:</span>
-                  {renderValue(asset.parking || '—', 'parking')}
+                  {renderValue(asset.parking ?? '—', 'parking')}
                 </div>
                 <div className="flex justify-between rtl:flex-row-reverse">
                   <span className="text-muted-foreground">פרויקטים סמוכים:</span>
-                  {renderValue(asset.nearbyProjects || '—', 'nearbyProjects')}
+                  {renderValue(asset.nearbyProjects ?? '—', 'nearbyProjects')}
                 </div>
               </CardContent>
             </Card>
@@ -893,7 +893,7 @@ export default function AssetDetail({ params }: { params: { id: string } }) {
                       <span className="text-muted-foreground">רבעון אחרון עם היתר:</span>
                       {renderValue(
                         <Badge variant={asset.lastPermitQ ? 'good' : 'outline'}>
-                          {asset.lastPermitQ || 'לא זמין'}
+                          {asset.lastPermitQ ?? 'לא זמין'}
                         </Badge>,
                         'lastPermitQ'
                       )}
@@ -1087,8 +1087,8 @@ export default function AssetDetail({ params }: { params: { id: string } }) {
                       </div>
                       <div className="text-center">
                         <div className="text-2xl font-bold">
-                          {asset.netSqm !== undefined && asset.netSqm !== null
-                            ? `₪${Math.round(asset.netSqm * 30500 / 1000000 * 100) / 100}M`
+                          {asset.area !== undefined && asset.area !== null
+                            ? `₪${Math.round(asset.area * 30500 / 1000000 * 100) / 100}M`
                             : '—'}
                         </div>
                         <div className="text-sm text-muted-foreground">שומת רמ״י</div>
@@ -1262,7 +1262,7 @@ export default function AssetDetail({ params }: { params: { id: string } }) {
                 </div>
 
                 <div className="pt-4 text-center text-sm text-muted-foreground">
-                  סה״כ {asset.documents?.length || 0} מסמכים זמינים
+                  סה״כ {asset.documents?.length ?? 0} מסמכים זמינים
                 </div>
               </CardContent>
             </Card>

--- a/realestate-broker-ui/app/assets/page.tsx
+++ b/realestate-broker-ui/app/assets/page.tsx
@@ -39,7 +39,7 @@ import {
   ChevronUp,
 } from "lucide-react";
 import { useAuth } from "@/lib/auth-context";
-import { Asset } from "@/lib/data";
+import type { Asset } from "@/lib/normalizers/asset";
 import AssetsTable from "@/components/AssetsTable";
 import DashboardLayout from "@/components/layout/dashboard-layout";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
@@ -377,12 +377,13 @@ export default function AssetsPage() {
   const filteredAssets = React.useMemo(
     () =>
       assets.filter((l) => {
-        if (
-          search &&
-          !l.address.toLowerCase().includes(search.toLowerCase()) &&
-          !l.city?.toLowerCase().includes(search.toLowerCase())
-        ) {
-          return false;
+        if (search) {
+          const lower = search.toLowerCase();
+          const addressLower = l.address?.toLowerCase();
+          const cityLower = l.city?.toLowerCase();
+          if (!(addressLower?.includes(lower) || cityLower?.includes(lower))) {
+            return false;
+          }
         }
         if (city && city !== "all" && l.city !== city) {
           return false;
@@ -390,10 +391,10 @@ export default function AssetsPage() {
         if (typeFilter && typeFilter !== "all" && l.type !== typeFilter) {
           return false;
         }
-        if (priceMin && l.price < priceMin) {
+        if (priceMin != null && l.price != null && l.price < priceMin) {
           return false;
         }
-        if (priceMax && l.price > priceMax) {
+        if (priceMax != null && l.price != null && l.price > priceMax) {
           return false;
         }
         return true;

--- a/realestate-broker-ui/components/AssetsTable.tsx
+++ b/realestate-broker-ui/components/AssetsTable.tsx
@@ -1,7 +1,7 @@
 'use client'
 import * as React from 'react'
 import { ColumnDef, flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table'
-import { Asset } from '@/lib/data'
+import type { Asset } from '@/lib/normalizers/asset'
 import { fmtCurrency, fmtNumber, fmtPct } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
 import { Table, THead, TBody, TR, TH, TD } from '@/components/ui/table'
@@ -72,13 +72,19 @@ function createColumns(onDelete?: (id: number) => void, onExport?: (asset: Asset
           <Link href={`/assets/${row.original.id}`}>{row.original.address}</Link>
         </div>
         <div className="text-xs text-sub">
-            {row.original.city ?? '—'}{row.original.neighborhood?` · ${row.original.neighborhood}`:''} · {row.original.type ?? '—'} · {row.original.netSqm !== undefined && row.original.netSqm !== null ? `${fmtNumber(row.original.netSqm)} מ"ר נטו` : '—'}
+            {row.original.city ?? '—'}{row.original.neighborhood?` · ${row.original.neighborhood}`:''} · {row.original.type ?? '—'} · {row.original.area !== undefined && row.original.area !== null ? `${fmtNumber(row.original.area)} מ"ר נטו` : '—'}
         </div>
       </div>
     )
   },
-  { header:'₪', accessorKey:'price', cell: info => <span className="font-mono">{fmtCurrency(info.getValue() as number)}</span> },
-  { header:'₪/מ"ר', accessorKey:'pricePerSqm', cell: info => <span className="font-mono">{fmtNumber(info.getValue() as number)}</span> },
+  { header:'₪', accessorKey:'price', cell: info => {
+      const v = info.getValue() as number | null | undefined
+      return <span className="font-mono">{v == null ? '—' : fmtCurrency(v)}</span>
+    } },
+  { header:'₪/מ"ר', accessorKey:'pricePerSqm', cell: info => {
+      const v = info.getValue() as number | null | undefined
+      return <span className="font-mono">{v == null ? '—' : fmtNumber(v)}</span>
+    } },
   { header:'Δ מול איזור', accessorKey:'deltaVsAreaPct', cell: info => {
       const value = info.getValue() as number | undefined
       return <Badge variant={typeof value === 'number' && value < 0 ? 'bad' : 'default'}>{fmtPct(value)}</Badge>
@@ -115,12 +121,18 @@ function createColumns(onDelete?: (id: number) => void, onExport?: (asset: Asset
       const value = info.getValue() as number | undefined
       return <Badge>{value !== undefined ? `${value}/5` : '—'}</Badge>
     } },
-  { header:'אנטנה (מ")', accessorKey:'antennaDistanceM', cell: info => <span className="font-mono">{fmtNumber(info.getValue() as number)}</span> },
+  { header:'אנטנה (מ")', accessorKey:'antennaDistanceM', cell: info => {
+      const v = info.getValue() as number | null | undefined
+      return <span className="font-mono">{v == null ? '—' : fmtNumber(v)}</span>
+    } },
   { header:'שטחי ציבור ≤300מ"', accessorKey:'greenWithin300m', cell: info => {
       const value = info.getValue() as boolean | undefined
       return <Badge variant={value === undefined ? 'default' : value ? 'good' : 'bad'}>{value === undefined ? '—' : value ? 'כן' : 'לא'}</Badge>
     } },
-  { header:'מקלט (מ")', accessorKey:'shelterDistanceM', cell: info => <span className="font-mono">{fmtNumber(info.getValue() as number)}</span> },
+  { header:'מקלט (מ")', accessorKey:'shelterDistanceM', cell: info => {
+      const v = info.getValue() as number | null | undefined
+      return <span className="font-mono">{v == null ? '—' : fmtNumber(v)}</span>
+    } },
   { header:'סיכון', accessorKey:'riskFlags', cell: info => <RiskCell flags={info.getValue() as string[]}/> },
   { header:'סטטוס נכס', accessorKey:'assetStatus', cell: info => {
     const status = info.getValue() as string
@@ -138,7 +150,10 @@ function createColumns(onDelete?: (id: number) => void, onExport?: (asset: Asset
       const value = info.getValue() as number | undefined
       return <Badge>{value !== undefined ? `${value}%` : '—'}</Badge>
     } },
-  { header:'שכ"ד', accessorKey:'rentEstimate', cell: info => <span className="font-mono">{fmtCurrency(info.getValue() as number)}</span> },
+  { header:'שכ"ד', accessorKey:'rentEstimate', cell: info => {
+      const v = info.getValue() as number | null | undefined
+      return <span className="font-mono">{v == null ? '—' : fmtCurrency(v)}</span>
+    } },
     { header:'תשואה', accessorKey:'capRatePct', cell: info => {
       const value = info.getValue() as number | undefined
       return <Badge>{typeof value === 'number' ? `${value.toFixed(1)}%` : '—'}</Badge>

--- a/realestate-broker-ui/lib/data.test.ts
+++ b/realestate-broker-ui/lib/data.test.ts
@@ -1,17 +1,17 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { 
-  assets, 
-  alerts, 
-  appraisalByAsset, 
-  compsByAsset, 
+import {
+  assets,
+  alerts,
+  appraisalByAsset,
+  compsByAsset,
   rightsByAsset,
   getActiveAlerts,
   getActiveAlertsCount,
   getActiveAssetsCount,
   deleteAsset,
-  type Asset,
   type Alert
 } from './data'
+import type { Asset } from './normalizers/asset'
 
 describe('Data Module', () => {
   describe('Static Data', () => {
@@ -27,7 +27,7 @@ describe('Data Module', () => {
       expect(firstAsset).toHaveProperty('bathrooms')
       expect(firstAsset).toHaveProperty('area')
       expect(firstAsset).toHaveProperty('type')
-      expect(firstAsset).toHaveProperty('status')
+      expect(firstAsset).toHaveProperty('assetStatus')
       expect(firstAsset).toHaveProperty('contactInfo')
     })
 
@@ -186,7 +186,7 @@ describe('Data Module', () => {
 
     it('getActiveAssetsCount returns correct count', () => {
       const count = getActiveAssetsCount()
-      const activeAssets = assets.filter(asset => asset.status === 'active')
+      const activeAssets = assets.filter(asset => asset.assetStatus === 'active')
       
       expect(count).toBe(activeAssets.length)
       expect(typeof count).toBe('number')
@@ -211,10 +211,10 @@ describe('Data Module', () => {
     })
 
     it('has valid asset status values', () => {
-      const validStatuses = ['active', 'pending', 'sold']
-      
+      const validStatuses = ['pending', 'enriching', 'done', 'failed']
+
       assets.forEach(asset => {
-        expect(validStatuses).toContain(asset.status)
+        expect(validStatuses).toContain(asset.assetStatus)
       })
     })
 
@@ -237,7 +237,7 @@ describe('Data Module', () => {
 
   describe('deleteAsset', () => {
     it('removes asset by id', () => {
-      const newAsset: Asset = { id: 1010, address: 'Del St', price: 1, bedrooms: 1, bathrooms: 1, area: 1, type: 'דירה', status: 'active', images: [], description: '', features: [], contactInfo: { agent: '', phone: '', email: '' } }
+      const newAsset: Asset = { id: 1010, address: 'Del St', price: 1, rooms: 1, bathrooms: 1, area: 1, type: 'דירה', assetStatus: 'active' }
       assets.push(newAsset)
       const removed = deleteAsset(1010)
       expect(removed?.id).toBe(1010)

--- a/realestate-broker-ui/lib/data.ts
+++ b/realestate-broker-ui/lib/data.ts
@@ -1,111 +1,6 @@
-export interface Asset {
-  id: number
-  address: string
-  price: number
-  bedrooms: number
-  bathrooms: number
-  area: number
-  type: string
-  status: "active" | "pending" | "sold"
-  images: string[]
-  description: string
-  features: string[]
-  contactInfo: {
-    agent: string
-    phone: string
-    email: string
-  }
-  
-  // Basic address fields
-  city?: string
-  neighborhood?: string
-  street?: string
-  number?: number
-  gush?: string
-  helka?: string
-  subhelka?: string
-  lat?: number
-  lon?: number
-  normalizedAddress?: string
-  
-  // Building details
-  buildingType?: string
-  floor?: number
-  totalFloors?: number
-  rooms?: number
-  totalArea?: number
-  balconyArea?: number
-  parkingSpaces?: number
-  storageRoom?: boolean
-  elevator?: boolean
-  airConditioning?: boolean
-  furnished?: boolean
-  renovated?: boolean
-  yearBuilt?: number
-  lastRenovation?: number
-  
-  // Financial fields
-  pricePerSqm?: number
-  rentEstimate?: number
-  
-  // Legal/Planning fields
-  buildingRights?: string
-  permitStatus?: string
-  permitDate?: string
-  zoning?: string
-  
-  // Additional properties for table display
-  netSqm?: number
-  pricePerSqmDisplay?: number
-  deltaVsAreaPct?: number
-  domPercentile?: number
-  competition1km?: string
-  riskFlags?: string[]
-  priceGapPct?: number
-  expectedPriceRange?: string
-  remainingRightsSqm?: number
-  program?: string
-  lastPermitQ?: string
-  noiseLevel?: number
-  greenWithin300m?: boolean
-  schoolsWithin500m?: boolean
-  modelPrice?: number
-  confidencePct?: number
-  capRatePct?: number
-  antennaDistanceM?: number
-  shelterDistanceM?: number
-  documents?: { name: string; url: string; type?: string }[]
-  
-  // Asset enrichment fields
-  assetId?: number
-  assetStatus?: string
-  sources?: string[]
-  primarySource?: string
-  permitDateDisplay?: string
-  permitStatusDisplay?: string
-  permitDetails?: string
-  permitMainArea?: number
-  permitServiceArea?: number
-  permitApplicant?: string
-  permitDocUrl?: string
-  mainRightsSqm?: number
-  serviceRightsSqm?: number
-  additionalPlanRights?: string
-  planStatus?: string
-  publicObligations?: string
-  publicTransport?: string
-  openSpacesNearby?: string
-  publicBuildings?: string
-  parking?: string
-  nearbyProjects?: string
-  rightsUsagePct?: number
-  legalRestrictions?: string
-  urbanRenewalPotential?: string
-  bettermentLevy?: string
-  _meta?: Record<string, { source: string; fetched_at: string; url?: string }>
-}
+import type { Asset } from './normalizers/asset'
 
-export const assets: Asset[] = [
+export const assets = [
   {
     id: 1,
     address: "רחוב הרצל 123, תל אביב",
@@ -114,7 +9,6 @@ export const assets: Asset[] = [
     bathrooms: 2,
     area: 85,
     type: "דירה",
-    status: "active",
     images: ["/placeholder-home.jpg"],
     description: "דירה מקסימה במרכז תל אביב עם נוף לים",
     features: ["מעלית", "חניה", "מרפסת", "משופצת"],
@@ -169,7 +63,6 @@ export const assets: Asset[] = [
       { name: "שומת מכרעת", url: "/docs/1/decisive-appraisal.pdf", type: "appraisal_decisive" },
       { name: "שומת רמ״י", url: "/docs/1/rmi-appraisal.pdf", type: "appraisal_rmi" }
     ],
-    netSqm: 85,
     pricePerSqmDisplay: 33529,
     deltaVsAreaPct: 2.5,
     domPercentile: 75,
@@ -250,7 +143,6 @@ export const assets: Asset[] = [
     bathrooms: 3,
     area: 120,
     type: "דירה",
-    status: "pending",
     images: ["/placeholder-home.jpg"],
     description: "דירת פנטהאוס מפוארת עם מרפסת גדולה",
     features: ["מעלית", "חניה", "מרפסת גדולה", "חדר עבודה"],
@@ -301,7 +193,6 @@ export const assets: Asset[] = [
       { name: "היתר בנייה", url: "/docs/2/permit.pdf", type: "permit" },
       { name: "שומת רמ״י", url: "/docs/2/rmi-appraisal.pdf", type: "appraisal_rmi" }
     ],
-    netSqm: 120,
     pricePerSqmDisplay: 35000,
     deltaVsAreaPct: 8.3,
     domPercentile: 90,
@@ -500,7 +391,7 @@ export function getActiveAlertsCount(): number {
 }
 
 export function getActiveAssetsCount(): number {
-  return assets.filter(asset => asset.status === "active").length
+  return assets.filter(asset => asset.assetStatus === "active").length
 }
 
 export function deleteAsset(id: number): Asset | null {

--- a/realestate-broker-ui/lib/normalizers/asset.ts
+++ b/realestate-broker-ui/lib/normalizers/asset.ts
@@ -1,0 +1,187 @@
+export type Asset = {
+  id: number;
+  address?: string | null;
+  city?: string | null;
+  neighborhood?: string | null;
+  street?: string | null;
+  number?: number | null;
+  type?: string | null;
+  bedrooms?: number | null;
+  rooms?: number | null;
+  bathrooms?: number | null;
+  area?: number | null; // net sqm
+  totalArea?: number | null; // total sqm
+  balconyArea?: number | null;
+  parkingSpaces?: number | null;
+  price?: number | null;
+  pricePerSqm?: number | null;
+  pricePerSqmDisplay?: number | null;
+  description?: string | null;
+  images?: string[];
+  features?: string[] | null;
+  contactInfo?: {
+    agent?: string | null;
+    phone?: string | null;
+    email?: string | null;
+  } | null;
+  gush?: string | null;
+  helka?: string | null;
+  subhelka?: string | null;
+  lat?: number | null;
+  lon?: number | null;
+  normalizedAddress?: string | null;
+  buildingType?: string | null;
+  floor?: number | null;
+  totalFloors?: number | null;
+  storageRoom?: boolean | null;
+  elevator?: boolean | null;
+  airConditioning?: boolean | null;
+  furnished?: boolean | null;
+  renovated?: boolean | null;
+  yearBuilt?: number | null;
+  lastRenovation?: number | null;
+  deltaVsAreaPct?: number | null;
+  domPercentile?: number | null;
+  competition1km?: string | null;
+  zoning?: string | null;
+  riskFlags?: string[] | null;
+  priceGapPct?: number | null;
+  expectedPriceRange?: string | null;
+  remainingRightsSqm?: number | null;
+  program?: string | null;
+  lastPermitQ?: string | null;
+  noiseLevel?: number | null;
+  greenWithin300m?: boolean | null;
+  schoolsWithin500m?: boolean | null;
+  modelPrice?: number | null;
+  confidencePct?: number | null;
+  capRatePct?: number | null;
+  antennaDistanceM?: number | null;
+  shelterDistanceM?: number | null;
+  rentEstimate?: number | null;
+  buildingRights?: string | null;
+  permitStatus?: string | null;
+  permitDate?: string | null;
+  assetStatus?: string | null;
+  documents?: any[];
+  assetId?: number | null;
+  sources?: string[] | null;
+  primarySource?: string | null;
+  permitDateDisplay?: string | null;
+  permitStatusDisplay?: string | null;
+  permitDetails?: string | null;
+  permitMainArea?: number | null;
+  permitServiceArea?: number | null;
+  permitApplicant?: string | null;
+  permitDocUrl?: string | null;
+  mainRightsSqm?: number | null;
+  serviceRightsSqm?: number | null;
+  additionalPlanRights?: string | null;
+  planStatus?: string | null;
+  publicObligations?: string | null;
+  publicTransport?: string | null;
+  openSpacesNearby?: string | null;
+  publicBuildings?: string | null;
+  parking?: string | null;
+  nearbyProjects?: string | null;
+  rightsUsagePct?: number | null;
+  legalRestrictions?: string | null;
+  urbanRenewalPotential?: string | null;
+  bettermentLevy?: string | null;
+  _meta?: Record<string, any>;
+};
+
+export function determineAssetType(asset: any): string | null {
+  return asset?.propertyType || asset?.property_type || asset?.type || null;
+}
+
+export function normalizeFromBackend(row: any): Asset {
+  return {
+    id: Number(row.id ?? row.assetId ?? row.external_id),
+    address: row.address ?? null,
+    city: row.city ?? null,
+    neighborhood: row.neighborhood ?? null,
+    street: row.street ?? null,
+    number: row.number ?? null,
+    type: determineAssetType(row),
+    bedrooms: row.bedrooms ?? null,
+    rooms: row.rooms ?? row.bedrooms ?? null,
+    bathrooms: row.bathrooms ?? null,
+    area: row.area ?? row.netSqm ?? null,
+    totalArea: row.totalArea ?? row.totalSqm ?? null,
+    balconyArea: row.balconyArea ?? row.balcony_area ?? null,
+    parkingSpaces: row.parkingSpaces ?? row.parking_spaces ?? null,
+    price: row.price ?? null,
+    pricePerSqm: row.pricePerSqm ?? row.ppsqm ?? null,
+    pricePerSqmDisplay: row.pricePerSqmDisplay ?? row.price_per_sqm_display ?? null,
+    description: row.description ?? null,
+    images: row.images ?? row.photos ?? [],
+    features: row.features ?? null,
+    contactInfo: row.contactInfo ?? row.contact_info ?? null,
+    gush: row.gush ?? null,
+    helka: row.helka ?? null,
+    subhelka: row.subhelka ?? null,
+    lat: row.lat ?? null,
+    lon: row.lon ?? null,
+    normalizedAddress: row.normalizedAddress ?? row.normalized_address ?? null,
+    buildingType: row.buildingType ?? row.building_type ?? null,
+    floor: row.floor ?? null,
+    totalFloors: row.totalFloors ?? row.total_floors ?? null,
+    storageRoom: row.storageRoom ?? row.storage_room ?? null,
+    elevator: row.elevator ?? null,
+    airConditioning: row.airConditioning ?? row.air_conditioning ?? null,
+    furnished: row.furnished ?? null,
+    renovated: row.renovated ?? null,
+    yearBuilt: row.yearBuilt ?? row.year_built ?? null,
+    lastRenovation: row.lastRenovation ?? row.last_renovation ?? null,
+    deltaVsAreaPct: row.deltaVsAreaPct ?? row.delta_vs_area_pct ?? null,
+    domPercentile: row.domPercentile ?? row.dom_percentile ?? null,
+    competition1km: row.competition1km ?? row.competition_1km ?? null,
+    zoning: row.zoning ?? null,
+    riskFlags: row.riskFlags ?? row.risk_flags ?? null,
+    priceGapPct: row.priceGapPct ?? row.price_gap_pct ?? null,
+    expectedPriceRange: row.expectedPriceRange ?? row.expected_price_range ?? null,
+    remainingRightsSqm: row.remainingRightsSqm ?? row.remaining_rights_sqm ?? null,
+    program: row.program ?? null,
+    lastPermitQ: row.lastPermitQ ?? row.last_permit_q ?? null,
+    noiseLevel: row.noiseLevel ?? row.noise_level ?? null,
+    greenWithin300m: row.greenWithin300m ?? row.green_within_300m ?? null,
+    schoolsWithin500m: row.schoolsWithin500m ?? row.schools_within_500m ?? null,
+    modelPrice: row.modelPrice ?? row.model_price ?? null,
+    confidencePct: row.confidencePct ?? row.confidence_pct ?? null,
+    capRatePct: row.capRatePct ?? row.cap_rate_pct ?? null,
+    antennaDistanceM: row.antennaDistanceM ?? row.antenna_distance_m ?? null,
+    shelterDistanceM: row.shelterDistanceM ?? row.shelter_distance_m ?? null,
+    rentEstimate: row.rentEstimate ?? row.rent_estimate ?? null,
+    buildingRights: row.buildingRights ?? row.building_rights ?? null,
+    permitStatus: row.permitStatus ?? row.permit_status ?? null,
+    permitDate: row.permitDate ?? row.permit_date ?? null,
+    assetStatus: row.assetStatus ?? row.asset_status ?? row.status ?? null,
+    documents: row.documents ?? [],
+    assetId: row.assetId ?? row.asset_id ?? null,
+    sources: row.sources ?? null,
+    primarySource: row.primarySource ?? row.primary_source ?? null,
+    permitDateDisplay: row.permitDateDisplay ?? row.permit_date_display ?? null,
+    permitStatusDisplay: row.permitStatusDisplay ?? row.permit_status_display ?? null,
+    permitDetails: row.permitDetails ?? row.permit_details ?? null,
+    permitMainArea: row.permitMainArea ?? row.permit_main_area ?? null,
+    permitServiceArea: row.permitServiceArea ?? row.permit_service_area ?? null,
+    permitApplicant: row.permitApplicant ?? row.permit_applicant ?? null,
+    permitDocUrl: row.permitDocUrl ?? row.permit_doc_url ?? null,
+    mainRightsSqm: row.mainRightsSqm ?? row.main_rights_sqm ?? null,
+    serviceRightsSqm: row.serviceRightsSqm ?? row.service_rights_sqm ?? null,
+    additionalPlanRights: row.additionalPlanRights ?? row.additional_plan_rights ?? null,
+    planStatus: row.planStatus ?? row.plan_status ?? null,
+    publicObligations: row.publicObligations ?? row.public_obligations ?? null,
+    publicTransport: row.publicTransport ?? row.public_transport ?? null,
+    openSpacesNearby: row.openSpacesNearby ?? row.open_spaces_nearby ?? null,
+    publicBuildings: row.publicBuildings ?? row.public_buildings ?? null,
+    parking: row.parking ?? null,
+    nearbyProjects: row.nearbyProjects ?? row.nearby_projects ?? null,
+    rightsUsagePct: row.rightsUsagePct ?? row.rights_usage_pct ?? null,
+    legalRestrictions: row.legalRestrictions ?? row.legal_restrictions ?? null,
+    urbanRenewalPotential: row.urbanRenewalPotential ?? row.urban_renewal_potential ?? null,
+    bettermentLevy: row.bettermentLevy ?? row.betterment_levy ?? null,
+    _meta: row._meta ?? undefined,
+  };
+}


### PR DESCRIPTION
## Summary
- guard asset listing filters against missing address or price values
- drop redundant `netSqm` field in favor of `area` across the Asset DTO and UI
- update reports and asset views to compute metrics from `area`

## Testing
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd200253f08328944e66624bf80b88