### PR TITLE
refactor: introduce design system with badges and cards

### DIFF
--- a/realestate-broker-ui/app/alerts/page.tsx
+++ b/realestate-broker-ui/app/alerts/page.tsx
@@ -4,7 +4,7 @@ import DashboardLayout from '@/components/layout/dashboard-layout'
 import { DashboardShell, DashboardHeader } from '@/components/layout/dashboard-shell'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
+import { Badge } from '@/components/ui/Badge'
 import { Bell, CheckCircle, Clock, TrendingDown, Home, FileText, Hammer } from 'lucide-react'
 import { alerts, type Alert } from '@/lib/data'
 
@@ -28,13 +28,13 @@ const getAlertIcon = (type: Alert['type']) => {
 const getPriorityColor = (priority: Alert['priority']) => {
   switch (priority) {
     case 'high':
-      return 'destructive'
+      return 'error'
     case 'medium':
-      return 'default'
+      return 'warning'
     case 'low':
-      return 'secondary'
+      return 'neutral'
     default:
-      return 'outline'
+      return 'neutral'
   }
 }
 
@@ -128,7 +128,7 @@ export default function AlertsPage() {
               <CardHeader>
                 <CardTitle className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
                   <span>התראות אחרונות</span>
-                  <Badge variant="outline" className="w-fit">{unreadCount} לא נקראו</Badge>
+                  <Badge variant="accent" className="w-fit">{unreadCount} לא נקראו</Badge>
                 </CardTitle>
               </CardHeader>
               <CardContent>
@@ -241,10 +241,10 @@ export default function AlertsPage() {
                         key={priority}
                         variant={
                           selectedPriorities.includes(priority as Alert['priority'])
-                            ? 'default'
-                            : 'outline'
+                            ? 'primary'
+                            : 'neutral'
                         }
-                        className="cursor-pointer hover:bg-primary hover:text-primary-foreground"
+                        className="cursor-pointer"
                         onClick={() => togglePriority(priority as Alert['priority'])}
                       >
                         {getPriorityText(priority as Alert['priority'])}
@@ -261,10 +261,10 @@ export default function AlertsPage() {
                         key={type}
                         variant={
                           selectedTypes.includes(type as Alert['type'])
-                            ? 'default'
-                            : 'outline'
+                            ? 'primary'
+                            : 'neutral'
                         }
-                        className="cursor-pointer hover:bg-primary hover:text-primary-foreground"
+                        className="cursor-pointer"
                         onClick={() => toggleType(type as Alert['type'])}
                       >
                         {type === 'price_drop' && 'ירידת מחיר'}

--- a/realestate-broker-ui/app/assets/[id]/page.tsx
+++ b/realestate-broker-ui/app/assets/[id]/page.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Card as SimpleCard, CardHeader as SimpleCardHeader, CardBody as SimpleCardBody, CardFooter as SimpleCardFooter } from '@/components/ui/Card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -511,11 +512,9 @@ export default function AssetDetail({ params }: { params: { id: string } }) {
 
           <TabsContent value="analysis" className="space-y-4">
             <div className="grid gap-4 md:grid-cols-2">
-              <Card>
-                <CardHeader>
-                  <CardTitle>פרטי הנכס</CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-2">
+              <SimpleCard>
+                <SimpleCardHeader>פרטי הנכס</SimpleCardHeader>
+                <SimpleCardBody className="space-y-2">
                   <div className="flex justify-between rtl:flex-row-reverse">
                     <span className="text-muted-foreground">סוג:</span>
                     <span>{asset.type ?? '—'}</span>
@@ -538,8 +537,8 @@ export default function AssetDetail({ params }: { params: { id: string } }) {
                       {asset.confidencePct}%
                     </Badge>
                   </div>
-                </CardContent>
-              </Card>
+                </SimpleCardBody>
+              </SimpleCard>
 
               <Card>
                 <CardHeader>
@@ -791,23 +790,21 @@ export default function AssetDetail({ params }: { params: { id: string } }) {
                   </div>
                 </div>
 
-                {asset.riskFlags && asset.riskFlags.length > 0 && (
-                  <div>
-                    <h3 className="font-medium mb-2">סיכונים</h3>
-                    <div className="flex flex-wrap gap-2">
-                      {asset.riskFlags.map((flag: string, i: number) => (
-                        <Badge 
-                          key={i} 
-                          variant={flag.includes('שימור') ? 'bad' : 'warn'}
-                        >
-                          {flag}
-                        </Badge>
-                      ))}
-                    </div>
-                  </div>
-                )}
               </CardContent>
             </Card>
+
+            {asset.riskFlags && asset.riskFlags.length > 0 && (
+              <SimpleCard>
+                <SimpleCardHeader>סיכונים</SimpleCardHeader>
+                <SimpleCardBody className="flex flex-wrap gap-2">
+                  {asset.riskFlags.map((flag: string, i: number) => (
+                    <Badge key={i} variant={flag.includes('שימור') ? 'bad' : 'warn'}>
+                      {flag}
+                    </Badge>
+                  ))}
+                </SimpleCardBody>
+              </SimpleCard>
+            )}
 
             <Card>
               <CardHeader>
@@ -840,11 +837,9 @@ export default function AssetDetail({ params }: { params: { id: string } }) {
 
           <TabsContent value="permits" className="space-y-4">
             <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-              <Card>
-                <CardHeader>
-                  <CardTitle>פרטי היתר</CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-2">
+              <SimpleCard>
+                <SimpleCardHeader>פרטי היתר</SimpleCardHeader>
+                <SimpleCardBody className="space-y-2">
                   <div className="flex justify-between rtl:flex-row-reverse">
                     <span className="text-muted-foreground">תאריך היתר:</span>
                     {renderValue(asset.permitDate, 'permitDate')}
@@ -880,8 +875,8 @@ export default function AssetDetail({ params }: { params: { id: string } }) {
                       'permitDocUrl'
                     )}
                   </div>
-                </CardContent>
-              </Card>
+                </SimpleCardBody>
+              </SimpleCard>
 
               <Card>
                 <CardHeader>
@@ -960,11 +955,9 @@ export default function AssetDetail({ params }: { params: { id: string } }) {
           </TabsContent>
 
           <TabsContent value="transactions" className="space-y-4">
-            <Card>
-              <CardHeader>
-                <CardTitle>עיסקאות השוואה</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
+            <SimpleCard>
+              <SimpleCardHeader>עיסקאות השוואה</SimpleCardHeader>
+              <SimpleCardBody className="space-y-4">
                 <div className="grid gap-4 md:grid-cols-3">
                   <div className="text-center">
                     <div className="text-2xl font-bold flex items-center justify-center gap-1">
@@ -991,9 +984,9 @@ export default function AssetDetail({ params }: { params: { id: string } }) {
                     </div>
                     <div className="text-sm text-muted-foreground">פער מהאזור</div>
                   </div>
-                </div>
-              </CardContent>
-            </Card>
+                  </div>
+                </SimpleCardBody>
+              </SimpleCard>
 
             <Card>
               <CardHeader>

--- a/realestate-broker-ui/app/reports/page.tsx
+++ b/realestate-broker-ui/app/reports/page.tsx
@@ -3,10 +3,9 @@
 import React, { useEffect, useState } from 'react'
 import DashboardLayout from '@/components/layout/dashboard-layout'
 import { DashboardShell, DashboardHeader } from '@/components/layout/dashboard-shell'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Table, TableHeader, TableHead, TableRow, TableBody, TableCell } from '@/components/ui/table'
+import { Card, CardHeader, CardBody } from '@/components/ui/Card'
 import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
+import { Badge } from '@/components/ui/Badge'
 import { FileText, Download, Eye, Calendar, MapPin, Trash2, ExternalLink, Loader2 } from 'lucide-react'
 import Link from 'next/link'
 
@@ -120,139 +119,108 @@ export default function ReportsPage() {
           text={`${reports.length} דוחות שנוצרו עבור נכסים`}
         />
         
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <FileText className="h-5 w-5" />
-              דוחות נכסים
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="p-0">
-            <div className="w-full overflow-x-auto">
-              <Table className="min-w-full">
-                <TableHeader>
-                  <TableRow>
-                    <TableHead className="text-right whitespace-nowrap">נכס</TableHead>
-                    <TableHead className="text-right whitespace-nowrap">סוג דוח</TableHead>
-                    <TableHead className="text-right whitespace-nowrap">סטטוס</TableHead>
-                    <TableHead className="text-right whitespace-nowrap">נוצר ב</TableHead>
-                    <TableHead className="text-right whitespace-nowrap">פעולות</TableHead>
-                  </TableRow>
-                </TableHeader>
-                    <TableBody>
-                      {displayReports.length === 0 ? (
-                        <TableRow>
-                          <TableCell colSpan={5} className="text-center py-8 text-muted-foreground">
-                            <div className="flex flex-col items-center gap-2">
-                              <FileText className="h-8 w-8 opacity-50" />
-                              <p>אין דוחות זמינים</p>
-                              <p className="text-sm">דוחות יופיעו כאן לאחר שייווצרו</p>
-                            </div>
-                          </TableCell>
-                        </TableRow>
-                      ) : (
-                        displayReports.map(report => (
-                          <TableRow 
-                            key={report.id} 
-                            className={`hover:bg-blue-50/50 hover:shadow-sm cursor-pointer transition-all duration-200 group border-l-4 transition-colors ${
-                              clickedRow === report.id 
-                                ? 'bg-blue-100/70 border-l-blue-600 shadow-md' 
-                                : 'border-l-transparent hover:border-l-blue-500'
-                            }`}
-                            onClick={() => handleRowClick(report)}
-                            onKeyDown={(e) => {
-                              if (e.key === 'Enter' || e.key === ' ') {
-                                e.preventDefault()
-                                handleRowClick(report)
-                              }
-                            }}
-                            tabIndex={0}
-                            role="button"
-                            aria-label={`צפה בדוח עבור ${report.address}`}
-                          >
-                            <TableCell>
-                              <div>
-                                <div className="font-semibold group-hover:text-primary transition-colors">
-                                  {report.address}
-                                </div>
-                                <div className="text-xs text-muted-foreground flex items-center gap-1">
-                                  <MapPin className="h-3 w-3" />
-                                  <span>
-                                    {clickedRow === report.id ? 'פותח דוח...' : 'לחץ לצפייה בדוח'}
-                                  </span>
-                                  {clickedRow === report.id ? (
-                                    <Loader2 className="h-3 w-3 animate-spin text-blue-600" />
-                                  ) : (
-                                    <ExternalLink className="h-3 w-3 opacity-60 group-hover:opacity-100 transition-opacity" />
-                                  )}
-                                </div>
-                              </div>
-                            </TableCell>
-                            <TableCell>
-                              <Badge variant="outline">
-                                {report.type || 'דוח כללי'}
-                              </Badge>
-                            </TableCell>
-                            <TableCell>
-                              <Badge variant="good">
-                                {report.status ? getStatusHebrew(report.status) : 'הושלם'}
-                              </Badge>
-                            </TableCell>
-                            <TableCell>
-                              <div className="flex items-center gap-2">
-                                <Calendar className="h-4 w-4 text-muted-foreground" />
-                                <span className="text-sm">
-                                  {new Date(report.createdAt).toLocaleDateString('he-IL', {
-                                    year: 'numeric',
-                                    month: 'short',
-                                    day: 'numeric',
-                                    hour: '2-digit',
-                                    minute: '2-digit'
-                                  })}
-                                </span>
-                              </div>
-                            </TableCell>
-                            <TableCell>
-                              <div className="flex gap-2 justify-end" onClick={(e) => e.stopPropagation()}>
-                                <Button variant="ghost" size="sm" asChild>
-                                  <Link href={report.url} target="_blank">
-                                    <Eye className="h-4 w-4 ml-2" />
-                                    תצוגה
-                                  </Link>
-                                </Button>
-                                <Button variant="outline" size="sm" asChild>
-                                  <a href={report.url} download>
-                                    <Download className="h-4 w-4 ml-2" />
-                                    הורדה
-                                  </a>
-                                </Button>
-                                <Button 
-                                  variant="destructive" 
-                                  size="sm"
-                                  onClick={() => handleDeleteReport(report.id)}
-                                  disabled={deleting === report.id}
-                                >
-                                  <Trash2 className="h-4 w-4 ml-2" />
-                                  {deleting === report.id ? 'מוחק...' : 'מחיקה'}
-                                </Button>
-                              </div>
-                            </TableCell>
-                          </TableRow>
-                        ))
-                      )}
-                    </TableBody>
-                  </Table>
-                </div>
-              </CardContent>
+        <div className="space-y-4">
+          {displayReports.length === 0 ? (
+            <Card>
+              <CardBody className="flex flex-col items-center gap-2 py-8 text-muted-foreground">
+                <FileText className="h-8 w-8 opacity-50" />
+                <p>אין דוחות זמינים</p>
+                <p className="text-sm">דוחות יופיעו כאן לאחר שייווצרו</p>
+              </CardBody>
             </Card>
+          ) : (
+            displayReports.map(report => (
+              <Card
+                key={report.id}
+                className={`cursor-pointer border-l-4 transition-colors ${
+                  clickedRow === report.id
+                    ? 'border-l-primary bg-blue-50'
+                    : 'border-l-transparent hover:border-l-primary'
+                }`}
+                onClick={() => handleRowClick(report)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault()
+                    handleRowClick(report)
+                  }
+                }}
+                tabIndex={0}
+                role="button"
+                aria-label={`צפה בדוח עבור ${report.address}`}
+              >
+                <CardHeader className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+                  <div>
+                    <div className="font-semibold flex items-center gap-2">
+                      {report.address}
+                    </div>
+                    <div className="text-xs text-muted-foreground flex items-center gap-1">
+                      <MapPin className="h-3 w-3" />
+                      <span>
+                        {clickedRow === report.id ? 'פותח דוח...' : 'לחץ לצפייה בדוח'}
+                      </span>
+                      {clickedRow === report.id ? (
+                        <Loader2 className="h-3 w-3 animate-spin text-primary" />
+                      ) : (
+                        <ExternalLink className="h-3 w-3 opacity-60" />
+                      )}
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Badge variant="accent">{report.type || 'דוח כללי'}</Badge>
+                    <Badge variant="success">
+                      {report.status ? getStatusHebrew(report.status) : 'הושלם'}
+                    </Badge>
+                  </div>
+                </CardHeader>
+                <CardBody className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <Calendar className="h-4 w-4" />
+                    <span>
+                      {new Date(report.createdAt).toLocaleDateString('he-IL', {
+                        year: 'numeric',
+                        month: 'short',
+                        day: 'numeric',
+                        hour: '2-digit',
+                        minute: '2-digit'
+                      })}
+                    </span>
+                  </div>
+                  <div className="flex gap-2 sm:ml-auto" onClick={(e) => e.stopPropagation()}>
+                    <Button variant="ghost" size="sm" asChild>
+                      <Link href={report.url} target="_blank">
+                        <Eye className="h-4 w-4 ml-2" />
+                        תצוגה
+                      </Link>
+                    </Button>
+                    <Button variant="outline" size="sm" asChild>
+                      <a href={report.url} download>
+                        <Download className="h-4 w-4 ml-2" />
+                        הורדה
+                      </a>
+                    </Button>
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      onClick={() => handleDeleteReport(report.id)}
+                      disabled={deleting === report.id}
+                    >
+                      <Trash2 className="h-4 w-4 ml-2" />
+                      {deleting === report.id ? 'מוחק...' : 'מחיקה'}
+                    </Button>
+                  </div>
+                </CardBody>
+              </Card>
+            ))
+          )}
+        </div>
 
-            {/* Footer */}
-            <div className="flex items-center justify-between mt-6">
-              <p className="text-sm text-muted-foreground">
-                מציג {displayReports.length} דוחות עם נתונים מלאים
-              </p>
-            </div>
-          </DashboardShell>
-        </DashboardLayout>
+        {/* Footer */}
+        <div className="flex items-center justify-between mt-6">
+          <p className="text-sm text-muted-foreground">
+            מציג {displayReports.length} דוחות עם נתונים מלאים
+          </p>
+        </div>
+      </DashboardShell>
+    </DashboardLayout>
   )
 }

--- a/realestate-broker-ui/components/AssetsTable.tsx
+++ b/realestate-broker-ui/components/AssetsTable.tsx
@@ -3,16 +3,16 @@ import * as React from 'react'
 import { ColumnDef, flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import type { Asset } from '@/lib/normalizers/asset'
 import { fmtCurrency, fmtNumber, fmtPct } from '@/lib/utils'
-import { Badge } from '@/components/ui/badge'
+import { Badge } from '@/components/ui/Badge'
 import { Table, THead, TBody, TR, TH, TD } from '@/components/ui/table'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { Trash2, Download } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 
-function RiskCell({ flags }: { flags?: string[] }){ 
-  if(!flags || flags.length===0) return <Badge variant='good'>ללא</Badge>; 
-  return <div className="flex gap-1 flex-wrap">{flags.map((f,i)=><Badge key={i} variant={f.includes('שימור')?'bad':f.includes('אנטנה')?'warn':'default'}>{f}</Badge>)}</div> 
+function RiskCell({ flags }: { flags?: string[] }){
+  if(!flags || flags.length===0) return <Badge variant='success'>ללא</Badge>;
+  return <div className="flex gap-1 flex-wrap">{flags.map((f,i)=><Badge key={i} variant={f.includes('שימור')?'error':f.includes('אנטנה')?'warning':'neutral'}>{f}</Badge>)}</div>
 }
 
 function exportAssetsCsv(assets: Asset[]) {
@@ -87,7 +87,7 @@ function createColumns(onDelete?: (id: number) => void, onExport?: (asset: Asset
     } },
   { header:'Δ מול איזור', accessorKey:'deltaVsAreaPct', cell: info => {
       const value = info.getValue() as number | undefined
-      return <Badge variant={typeof value === 'number' && value < 0 ? 'bad' : 'default'}>{fmtPct(value)}</Badge>
+      return <Badge variant={typeof value === 'number' && value < 0 ? 'error' : 'neutral'}>{fmtPct(value)}</Badge>
     } },
   { header:'ימי שוק (אחוזון)', accessorKey:'domPercentile', cell: info => {
       const value = info.getValue() as number | undefined
@@ -127,7 +127,7 @@ function createColumns(onDelete?: (id: number) => void, onExport?: (asset: Asset
     } },
   { header:'שטחי ציבור ≤300מ"', accessorKey:'greenWithin300m', cell: info => {
       const value = info.getValue() as boolean | undefined
-      return <Badge variant={value === undefined ? 'default' : value ? 'good' : 'bad'}>{value === undefined ? '—' : value ? 'כן' : 'לא'}</Badge>
+      return <Badge variant={value === undefined ? 'neutral' : value ? 'success' : 'error'}>{value === undefined ? '—' : value ? 'כן' : 'לא'}</Badge>
     } },
   { header:'מקלט (מ")', accessorKey:'shelterDistanceM', cell: info => {
       const v = info.getValue() as number | null | undefined
@@ -136,15 +136,15 @@ function createColumns(onDelete?: (id: number) => void, onExport?: (asset: Asset
   { header:'סיכון', accessorKey:'riskFlags', cell: info => <RiskCell flags={info.getValue() as string[]}/> },
   { header:'סטטוס נכס', accessorKey:'assetStatus', cell: info => {
     const status = info.getValue() as string
-    if (!status) return <Badge variant="default">—</Badge>
-    const variant = status === 'done' ? 'good' : status === 'failed' ? 'bad' : 'warn'
+    if (!status) return <Badge variant="neutral">—</Badge>
+    const variant = status === 'done' ? 'success' : status === 'failed' ? 'error' : 'warning'
     const label = status === 'done' ? 'מוכן' : status === 'failed' ? 'שגיאה' : status === 'enriching' ? 'מתעשר' : 'ממתין'
     return <Badge variant={variant}>{label}</Badge>
   }},
   { header:'מחיר מודל', accessorKey:'modelPrice', cell: info => <span className="font-mono">{fmtCurrency(info.getValue() as number)}</span> },
   { header:'פער למחיר', accessorKey:'priceGapPct', cell: info => {
       const value = info.getValue() as number | undefined
-      return <Badge variant={typeof value === 'number' && value > 0 ? 'warn' : 'good'}>{fmtPct(value)}</Badge>
+      return <Badge variant={typeof value === 'number' && value > 0 ? 'warning' : 'success'}>{fmtPct(value)}</Badge>
     } },
   { header:'רמת ביטחון', accessorKey:'confidencePct', cell: info => {
       const value = info.getValue() as number | undefined

--- a/realestate-broker-ui/components/DataBadge.tsx
+++ b/realestate-broker-ui/components/DataBadge.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as Tooltip from '@radix-ui/react-tooltip';
 import { Database } from 'lucide-react';
+import { Badge } from '@/components/ui/Badge';
 
 interface DataBadgeProps {
   source?: string;
@@ -16,15 +17,16 @@ export default function DataBadge({ source, fetchedAt, url, defaultOpen = false 
     <Tooltip.Provider delayDuration={0}>
       <Tooltip.Root defaultOpen={defaultOpen}>
         <Tooltip.Trigger asChild>
-          <span
+          <Badge
+            variant="neutral"
             dir="rtl"
-            className="inline-flex items-center gap-1 text-[10px] text-muted-foreground border rounded px-1 whitespace-nowrap rtl:flex-row-reverse"
+            className="gap-1 text-[10px] px-1 rtl:flex-row-reverse font-normal"
             data-testid="data-badge"
           >
             <Database className="w-3 h-3" />
             <span className="hidden sm:inline">{source}</span>
             <span className="hidden sm:inline">{date}</span>
-          </span>
+          </Badge>
         </Tooltip.Trigger>
         <Tooltip.Portal>
           <Tooltip.Content

--- a/realestate-broker-ui/components/ui/Badge.tsx
+++ b/realestate-broker-ui/components/ui/Badge.tsx
@@ -1,0 +1,44 @@
+import React, { type HTMLAttributes } from 'react'
+import { cn } from '@/lib/utils'
+
+const variants: Record<BadgeVariant, string> = {
+  primary: 'bg-primary text-white',
+  accent: 'bg-accent text-white',
+  success: 'bg-success text-white',
+  warning: 'bg-warning text-black',
+  error: 'bg-error text-white',
+  neutral:
+    'bg-neutral-200 text-neutral-800 dark:bg-neutral-700 dark:text-neutral-200',
+}
+
+export type BadgeVariant =
+  | 'success'
+  | 'warning'
+  | 'error'
+  | 'neutral'
+  | 'accent'
+  | 'primary'
+
+interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
+  variant?: BadgeVariant
+}
+
+export function Badge({
+  variant = 'neutral',
+  className,
+  ...props
+}: BadgeProps) {
+  return (
+    <span
+      data-slot="badge"
+      className={cn(
+        'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium',
+        variants[variant],
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export default Badge

--- a/realestate-broker-ui/components/ui/Card.tsx
+++ b/realestate-broker-ui/components/ui/Card.tsx
@@ -1,0 +1,38 @@
+import React, { type HTMLAttributes } from 'react'
+import { cn } from '@/lib/utils'
+
+export function Card({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        'rounded-lg border bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-50 shadow',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export function CardHeader({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('border-b px-4 py-2 font-semibold', className)}
+      {...props}
+    />
+  )
+}
+
+export function CardBody({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('px-4 py-2', className)} {...props} />
+}
+
+export function CardFooter({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('border-t px-4 py-2', className)}
+      {...props}
+    />
+  )
+}
+
+export default Card

--- a/realestate-broker-ui/tailwind.config.ts
+++ b/realestate-broker-ui/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from 'tailwindcss'
+import colors from 'tailwindcss/colors'
 
 const config: Config = {
   darkMode: ["class"],
@@ -18,39 +19,32 @@ const config: Config = {
         sm: 'calc(var(--radius) - 4px)'
       },
       colors: {
-        border: "hsl(var(--border))",
-        input: "hsl(var(--input))",
-        ring: "hsl(var(--ring))",
-        background: "hsl(var(--background))",
-        foreground: "hsl(var(--foreground))",
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
         primary: {
-          DEFAULT: "hsl(var(--primary))",
-          foreground: "hsl(var(--primary-foreground))",
-        },
-        secondary: {
-          DEFAULT: "hsl(var(--secondary))",
-          foreground: "hsl(var(--secondary-foreground))",
-        },
-        destructive: {
-          DEFAULT: "hsl(var(--destructive))",
-          foreground: "hsl(var(--destructive-foreground))",
-        },
-        muted: {
-          DEFAULT: "hsl(var(--muted))",
-          foreground: "hsl(var(--muted-foreground))",
+          DEFAULT: '#0A66C2',
+          foreground: '#ffffff',
         },
         accent: {
-          DEFAULT: "hsl(var(--accent))",
-          foreground: "hsl(var(--accent-foreground))",
+          DEFAULT: '#FF7A00',
+          foreground: '#ffffff',
         },
-        popover: {
-          DEFAULT: "hsl(var(--popover))",
-          foreground: "hsl(var(--popover-foreground))",
+        success: {
+          DEFAULT: '#22C55E',
+          foreground: '#ffffff',
         },
-        card: {
-          DEFAULT: "hsl(var(--card))",
-          foreground: "hsl(var(--card-foreground))",
+        warning: {
+          DEFAULT: '#FACC15',
+          foreground: '#000000',
         },
+        error: {
+          DEFAULT: '#EF4444',
+          foreground: '#ffffff',
+        },
+        neutral: colors.gray,
       },
       keyframes: {
         "accordion-down": {


### PR DESCRIPTION
## Summary
- define global color palette in Tailwind
- add reusable Badge and Card components with dark mode
- replace inline status labels and detail boxes with new components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd4a97f8b883288c33b2f73a31a0ae