### PR TITLE
Fix CRM view tests

### DIFF
--- a/backend-django/crm/serializers.py
+++ b/backend-django/crm/serializers.py
@@ -1,16 +1,82 @@
+import ast
+import json
+
 from rest_framework import serializers
+
 from .models import Contact, Lead, LeadStatus
+
+
+def _extract_list_from_request(serializer, field_name):
+    """Extract list values for ``field_name`` from the incoming request if possible."""
+
+    request = serializer.context.get("request") if serializer else None
+    if not request:
+        return None
+
+    data = getattr(request, "data", None)
+    if data is None or not hasattr(data, "getlist"):
+        return None
+
+    values = data.getlist(field_name)
+    if not values:
+        return []
+
+    return values
+
+
+def _coerce_json_like_value(value):
+    """Coerce string representations of JSON/collections into Python objects."""
+
+    if isinstance(value, (list, dict)) or value is None:
+        return value
+
+    if isinstance(value, str):
+        candidate = value.strip()
+        if candidate == "":
+            return []
+
+        try:
+            return json.loads(candidate)
+        except (ValueError, TypeError):
+            try:
+                return ast.literal_eval(candidate)
+            except (ValueError, SyntaxError, NameError):
+                return value
+
+    return value
 
 
 class ContactSerializer(serializers.ModelSerializer):
     """Serializer for Contact model."""
-    
-    tags = serializers.JSONField(required=False, allow_null=True)
+
+    tags = serializers.ListField(
+        child=serializers.CharField(), required=False, allow_empty=True, default=list
+    )
     
     class Meta:
         model = Contact
         fields = ["id", "name", "phone", "email", "tags", "created_at", "updated_at"]
         read_only_fields = ["id", "created_at", "updated_at"]
+
+    def to_internal_value(self, data):
+        """Ensure tags are consistently treated as a list when submitted via forms."""
+
+        mutable_data = dict(data.items()) if hasattr(data, "items") else dict(data)
+        request_tags = _extract_list_from_request(self, "tags")
+        if request_tags:
+            mutable_data["tags"] = request_tags
+        else:
+            raw_tags = mutable_data.get("tags")
+            if isinstance(raw_tags, str):
+                coerced = _coerce_json_like_value(raw_tags)
+                if isinstance(coerced, list):
+                    mutable_data["tags"] = coerced
+                elif coerced in ("", None):
+                    mutable_data["tags"] = []
+                else:
+                    mutable_data["tags"] = [str(coerced)]
+
+        return super().to_internal_value(mutable_data)
 
 
 class LeadSerializer(serializers.ModelSerializer):
@@ -31,11 +97,37 @@ class LeadSerializer(serializers.ModelSerializer):
     class Meta:
         model = Lead
         fields = [
-            "id", "contact", "contact_id", "asset_id", "asset_address", 
+            "id", "contact", "contact_id", "asset_id", "asset_address",
             "asset_price", "asset_rooms", "asset_area", "status", "notes",
             "last_activity_at", "created_at"
         ]
         read_only_fields = ["id", "last_activity_at", "created_at"]
+
+    def to_internal_value(self, data):
+        """Normalise notes submitted through multipart requests."""
+
+        mutable_data = dict(data.items()) if hasattr(data, "items") else dict(data)
+        request_notes = _extract_list_from_request(self, "notes")
+        if request_notes:
+            coerced = [_coerce_json_like_value(item) for item in request_notes]
+            if len(coerced) == 1 and isinstance(coerced[0], list):
+                mutable_data["notes"] = coerced[0]
+            else:
+                mutable_data["notes"] = coerced
+        else:
+            raw_notes = mutable_data.get("notes")
+            if isinstance(raw_notes, str):
+                coerced = _coerce_json_like_value(raw_notes)
+                if isinstance(coerced, list):
+                    mutable_data["notes"] = coerced
+                elif isinstance(coerced, dict):
+                    mutable_data["notes"] = [coerced]
+                elif coerced in ("", None):
+                    mutable_data["notes"] = []
+                else:
+                    mutable_data["notes"] = [coerced]
+
+        return super().to_internal_value(mutable_data)
 
     def validate(self, attrs):
         """Validate lead data."""
@@ -68,5 +160,5 @@ class LeadStatusUpdateSerializer(serializers.Serializer):
 
 class LeadNoteSerializer(serializers.Serializer):
     """Serializer for adding notes to leads."""
-    
-    text = serializers.CharField(max_length=1000, min_length=1)
+
+    text = serializers.CharField(max_length=1000, allow_blank=True)


### PR DESCRIPTION
## Summary
- normalize CRM serializers to accept form submissions for tags and notes and allow empty note validation
- add optional pagination, CSV export handling, and stricter asset lookups to CRM viewsets

## Testing
- pytest tests/crm/test_crm_views.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cd89ec35f883288ddec747caddb219