### PR TITLE
Reject empty addresses in GovMapCollector validation

### DIFF
--- a/orchestration/collectors/govmap_collector.py
+++ b/orchestration/collectors/govmap_collector.py
@@ -102,7 +102,9 @@ class GovMapCollector(BaseCollector):
             return None
 
     def validate_parameters(self, **kwargs) -> bool:
-        return isinstance(kwargs.get("address"), str)
+        """Validate that an address string is provided."""
+        address = kwargs.get("address")
+        return isinstance(address, str) and bool(address.strip())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ensure `GovMapCollector.validate_parameters` rejects blank address input by checking for non-empty strings

## Testing
- pytest tests/govmap/test_collector.py::test_validate_parameters_invalid tests/e2e/test_collectors_integration.py::TestCollectorsIntegration::test_govmap_collector

------
https://chatgpt.com/codex/tasks/task_e_68d13756dd0c8328b511b076ef6e2e95