### PR TITLE
feat: add advanced filters to assets table

### DIFF
--- a/realestate-broker-ui/components/TableToolbar.tsx
+++ b/realestate-broker-ui/components/TableToolbar.tsx
@@ -42,10 +42,17 @@ import {
 } from "lucide-react";
 import { useAnalytics } from "@/hooks/useAnalytics";
 
+interface FilterOptionOption {
+  value: string;
+  label: string;
+  count?: number;
+}
+
 interface FilterOption {
   key: string;
   label: string;
   value: string;
+  options?: FilterOptionOption[];
 }
 
 interface TableToolbarProps {
@@ -394,7 +401,16 @@ export default function TableToolbar({
                               </SelectTrigger>
                               <SelectContent>
                                 <SelectItem value="all">הכל</SelectItem>
-                                {/* Add more options based on filter type */}
+                                {filter.options?.map(option => (
+                                  <SelectItem key={option.value} value={option.value}>
+                                    <span className="flex justify-between gap-2">
+                                      <span>{option.label}</span>
+                                      {option.count !== undefined && (
+                                        <span className="text-xs text-muted-foreground">{option.count}</span>
+                                      )}
+                                    </span>
+                                  </SelectItem>
+                                ))}
                               </SelectContent>
                             </Select>
                           </div>


### PR DESCRIPTION
## Summary
- add neighborhood, zoning, risk, document, and status filters with URL sync and filtering on the assets page
- extend the assets table to surface new filter options, forward selections, and track filter usage
- update the toolbar to render advanced filter selects with option metadata

## Testing
- pnpm test -- --runInBand app/assets/page.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d3c477155c832898c49a18d9a99cdd