### PR TITLE
Align plan tests with 10-asset limit

### DIFF
--- a/tests/core/test_plan_api.py
+++ b/tests/core/test_plan_api.py
@@ -121,9 +121,9 @@ class TestPlanAPIEndpoints:
         assert data['plan_name'] == 'basic'
         assert data['display_name'] == 'Basic Plan'
         assert data['price'] == '149.00'
-        assert data['limits']['assets']['limit'] == 25
+        assert data['limits']['assets']['limit'] == 10
         assert data['limits']['assets']['used'] == 10
-        assert data['limits']['assets']['remaining'] == 15
+        assert data['limits']['assets']['remaining'] == 0
         assert data['features']['advanced_analytics'] is True
         assert data['features']['data_export'] is True
 

--- a/tests/core/test_plan_models.py
+++ b/tests/core/test_plan_models.py
@@ -216,12 +216,12 @@ class TestUserPlanModel:
         user_plan = UserPlan.objects.create(
             user=user,
             plan_type=plan_type,
-            assets_used=10
+            assets_used=5
         )
-        
+
         # Test asset limit
-        assert user_plan.can_use_feature('assets', 10) is True  # 10 + 10 = 20 < 25
-        assert user_plan.can_use_feature('assets', 20) is False  # 10 + 20 = 30 > 25
+        assert user_plan.can_use_feature('assets', 5) is True  # 5 + 5 = 10 <= 10
+        assert user_plan.can_use_feature('assets', 6) is False  # 5 + 6 = 11 > 10
         
         # Test unlimited features
         assert user_plan.can_use_feature('advanced_analytics') is True
@@ -246,10 +246,10 @@ class TestUserPlanModel:
         user_plan = UserPlan.objects.create(
             user=user,
             plan_type=plan_type,
-            assets_used=10
+            assets_used=4
         )
-        
-        assert user_plan.get_remaining_assets() == 15  # 25 - 10
+
+        assert user_plan.get_remaining_assets() == 6  # 10 - 4
 
     def test_user_plan_unlimited_assets(self):
         """Test unlimited assets handling"""

--- a/tests/core/test_plan_service.py
+++ b/tests/core/test_plan_service.py
@@ -144,9 +144,9 @@ class TestPlanService:
         assert plan_info['is_expired'] is False
         
         # Check limits
-        assert plan_info['limits']['assets']['limit'] == 25
+        assert plan_info['limits']['assets']['limit'] == 10
         assert plan_info['limits']['assets']['used'] == 10
-        assert plan_info['limits']['assets']['remaining'] == 15
+        assert plan_info['limits']['assets']['remaining'] == 0
         
         assert plan_info['limits']['reports']['limit'] == 50
         assert plan_info['limits']['reports']['used'] == 0
@@ -203,7 +203,7 @@ class TestPlanService:
         )
         
         # Create some assets
-        for i in range(10):
+        for i in range(9):
             Asset.objects.create(
                 scope_type="address",
                 street=f"Test Street {i}",


### PR DESCRIPTION
## Summary
- update plan API test expectations to reflect the 10-asset cap for the basic plan
- adjust plan model tests to validate feature usage and remaining assets against the reduced limit
- refresh plan service tests to check limit, remaining count, and validation logic for the new cap

## Testing
- pytest tests/core/test_plan_api.py::TestPlanAPIEndpoints::test_user_plan_info_authenticated \
       tests/core/test_plan_models.py::TestUserPlanModel::test_user_plan_can_use_feature \
       tests/core/test_plan_models.py::TestUserPlanModel::test_user_plan_get_remaining_assets \
       tests/core/test_plan_service.py::TestPlanService::test_get_user_plan_info \
       tests/core/test_plan_service.py::TestPlanService::test_validate_asset_creation_success

------
https://chatgpt.com/codex/tasks/task_e_68d432de6ba883288a92670f042ce196