### PR TITLE
Improve Yad2 collector location parameter usage

### DIFF
--- a/orchestration/collectors/yad2_collector.py
+++ b/orchestration/collectors/yad2_collector.py
@@ -1,6 +1,6 @@
 """Yad2 data collector implementation."""
 
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from yad2.scrapers.yad2_scraper import RealEstateListing, Yad2Scraper
 
@@ -12,6 +12,123 @@ class Yad2Collector(BaseCollector):
 
     def __init__(self, client: Optional[Yad2Scraper] = None) -> None:
         self.client = client or Yad2Scraper()
+
+    @staticmethod
+    def _extract_first_value(entry: Dict, keys: List[str]) -> Optional[str]:
+        """Return the first matching non-empty value for the provided keys."""
+
+        if not entry:
+            return None
+
+        for key in keys:
+            value = entry.get(key) if isinstance(entry, dict) else None
+            if value not in (None, "", []):
+                return value
+        return None
+
+    @staticmethod
+    def _coerce_numeric(value: Optional[str]) -> Optional[int]:
+        """Convert string/integer identifiers to integers when possible."""
+
+        if value is None:
+            return None
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str):
+            digits = value.strip()
+            if digits.isdigit():
+                return int(digits)
+        return None
+
+    @classmethod
+    def _prepare_location_parameters(cls, location: Dict) -> Dict[str, object]:
+        """Translate autocomplete response into search parameters."""
+
+        if not location:
+            return {}
+
+        params: Dict[str, object] = {}
+
+        cities = location.get("cities") or []
+        areas = location.get("areas") or []
+        top_areas = location.get("top_areas") or []
+        hoods = location.get("hoods") or []
+        streets = location.get("streets") or []
+
+        selected_city = cities[0] if cities else {}
+
+        city_id = cls._coerce_numeric(
+            cls._extract_first_value(selected_city, ["cityId", "id", "value"])
+        )
+        if city_id is not None:
+            params["city"] = city_id
+
+        top_area_id = cls._coerce_numeric(
+            cls._extract_first_value(
+                selected_city, ["topAreaId", "topArea", "regionId"]
+            )
+        )
+        if top_area_id is None and top_areas:
+            top_area_id = cls._coerce_numeric(
+                cls._extract_first_value(top_areas[0], ["topAreaId", "id", "value", "code"])
+            )
+        if top_area_id is not None:
+            params["topArea"] = top_area_id
+
+        area_id = cls._coerce_numeric(
+            cls._extract_first_value(selected_city, ["areaId", "area", "regionId"])
+        )
+        if area_id is None and areas:
+            area_id = cls._coerce_numeric(
+                cls._extract_first_value(areas[0], ["areaId", "id", "value"])
+            )
+        if area_id is not None:
+            params["area"] = area_id
+
+        if hoods:
+            hood_entry = None
+            if city_id is not None:
+                for hood in hoods:
+                    hood_city_id = cls._coerce_numeric(
+                        cls._extract_first_value(hood, ["cityId", "cityID", "city"])
+                    )
+                    if hood_city_id is not None and hood_city_id == city_id:
+                        hood_entry = hood
+                        break
+            hood_entry = hood_entry or hoods[0]
+            hood_id = cls._coerce_numeric(
+                cls._extract_first_value(
+                    hood_entry, ["hoodId", "id", "value", "neighborhoodId"]
+                )
+            )
+            if hood_id is not None:
+                params["neighborhood"] = hood_id
+
+        if streets:
+            street_entry = None
+            if city_id is not None:
+                for street in streets:
+                    street_city_id = cls._coerce_numeric(
+                        cls._extract_first_value(street, ["cityId", "cityID", "city"])
+                    )
+                    if street_city_id is not None and street_city_id == city_id:
+                        street_entry = street
+                        break
+            street_entry = street_entry or streets[0]
+
+            street_id = cls._extract_first_value(
+                street_entry, ["streetId", "id", "value"]
+            )
+            if street_id:
+                params["street"] = str(street_id)
+            else:
+                street_name = cls._extract_first_value(
+                    street_entry, ["name", "streetName", "text", "title"]
+                )
+                if street_name:
+                    params["street"] = street_name
+
+        return params
 
     def collect(self, address: str, max_pages: int = 1) -> List[RealEstateListing]:
         """Collect Yad2 listings for a given address.
@@ -27,12 +144,9 @@ class Yad2Collector(BaseCollector):
         try:
             location = self.client.fetch_location_autocomplete(address)
             if location:
-                city = location.get("cities") or []
-                streets = location.get("streets") or []
-                if city:
-                    self.client.set_search_parameters(city=city[0].get("id"))
-                if streets:
-                    self.client.set_search_parameters(street=streets[0].get("id"))
+                search_params = self._prepare_location_parameters(location)
+                if search_params:
+                    self.client.set_search_parameters(**search_params)
             return self.client.scrape_all_pages(max_pages=max_pages, delay=0)
         except Exception as e:
             # Handle captcha or other blocking issues gracefully

--- a/tests/orchestration/test_yad2_collector.py
+++ b/tests/orchestration/test_yad2_collector.py
@@ -1,0 +1,59 @@
+import pytest
+from unittest.mock import Mock
+
+from orchestration.collectors.yad2_collector import Yad2Collector
+
+
+@pytest.fixture
+def location_payload():
+    return {
+        "top_areas": [{"topAreaId": "2", "name": "מרכז"}],
+        "areas": [{"areaId": "1", "name": "תל אביב"}],
+        "cities": [
+            {
+                "cityId": "5000",
+                "name": "תל אביב-יפו",
+                "topAreaId": "2",
+                "areaId": "1",
+            }
+        ],
+        "hoods": [
+            {
+                "hoodId": "203",
+                "cityId": "5000",
+                "name": "רמת החייל",
+            }
+        ],
+        "streets": [
+            {
+                "streetId": "123",
+                "cityId": "5000",
+                "name": "הברזל",
+            }
+        ],
+    }
+
+
+def test_prepare_location_parameters(location_payload):
+    params = Yad2Collector._prepare_location_parameters(location_payload)
+
+    assert params["city"] == 5000
+    assert params["topArea"] == 2
+    assert params["area"] == 1
+    assert params["neighborhood"] == 203
+    assert params["street"] == "123"
+
+
+def test_collect_applies_location_parameters(location_payload):
+    mock_client = Mock()
+    mock_client.fetch_location_autocomplete.return_value = location_payload
+    mock_client.scrape_all_pages.return_value = ["listing"]
+
+    collector = Yad2Collector(client=mock_client)
+    result = collector.collect(address="הברזל 32 תל אביב", max_pages=2)
+
+    assert result == ["listing"]
+    mock_client.set_search_parameters.assert_called_once_with(
+        city=5000, topArea=2, area=1, neighborhood=203, street="123"
+    )
+    mock_client.scrape_all_pages.assert_called_once_with(max_pages=2, delay=0)


### PR DESCRIPTION
## Summary
- enrich the Yad2 collector with helpers that translate autocomplete responses into complete location search parameters
- ensure the collector applies all available location identifiers before scraping
- add targeted unit tests that verify parameter extraction and application

## Testing
- `pytest tests/orchestration/test_yad2_collector.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68d778043f448328a764da5a5daf2f9e