### PR TITLE
GovMap collector focused on SearchAndLocate metadata and document 

### DIFF
--- a/tests/govmap/test_collector.py
+++ b/tests/govmap/test_collector.py
@@ -39,16 +39,21 @@ def test_collect_success():
         assert y == 200.0
         return parcel_data
     
+    locate_result = {"data": [{"Values": ["111", "222"]}]}
     with mock.patch.object(collector.client, 'autocomplete', side_effect=mock_autocomplete), \
-         mock.patch.object(collector.client, 'get_parcel_data', side_effect=mock_get_parcel_data):
-        
+         mock.patch.object(collector.client, 'get_parcel_data', side_effect=mock_get_parcel_data), \
+         mock.patch.object(collector.client, 'search_and_locate_address', return_value=locate_result):
+
         result = collector.collect(address="Test Address")
-        
+
         assert result["address"] == "Test Address"
         assert result["x"] == 100.0
         assert result["y"] == 200.0
         assert "api_data" in result
         assert result["api_data"]["parcel"] == parcel_data
+        assert result["api_data"]["search_and_locate"] == locate_result
+        assert result["block"] == 111
+        assert result["parcel"] == 222
 
 
 def test_collect_with_api_failures():
@@ -69,17 +74,22 @@ def test_collect_with_api_failures():
     def mock_get_parcel_data(x, y):
         raise Exception("API Error")
     
+    locate_result = {"data": [{"Values": ["111", "222"]}]}
+
     with mock.patch.object(collector.client, 'autocomplete', side_effect=mock_autocomplete), \
-         mock.patch.object(collector.client, 'get_parcel_data', side_effect=mock_get_parcel_data):
-        
+         mock.patch.object(collector.client, 'get_parcel_data', side_effect=mock_get_parcel_data), \
+         mock.patch.object(collector.client, 'search_and_locate_address', return_value=locate_result):
+
         result = collector.collect(address="Test Address")
-        
+
         assert result["address"] == "Test Address"
         assert result["x"] == 100.0
         assert result["y"] == 200.0
         assert "api_data" in result
         # Parcel data should not be in the result due to API failure
         assert "parcel" not in result["api_data"]
+        assert result["block"] == 111
+        assert result["parcel"] == 222
 
 
 def test_validate_parameters_valid():


### PR DESCRIPTION
## Summary
- remove the GovMap client's embedded Taba plan search helpers so address enrichment stops at block/parcel lookup
- keep the GovMap collector focused on SearchAndLocate metadata and document that RAMI handles downstream plan retrieval
- update the GovMap client and collector unit tests to reflect the trimmed responsibilities

## Testing
- pytest tests/govmap -q

------
https://chatgpt.com/codex/tasks/task_e_68d785385e908328901b94b7e3219076