### PR TITLE
Decouple pipeline notifications from data persistence

### DIFF
--- a/orchestration/alerts.py
+++ b/orchestration/alerts.py
@@ -133,11 +133,18 @@ class Notifier:
         self.criteria = criteria
         self.alerts = alerts
 
-    def notify(self, listing: Any) -> None:
-        """Send notifications if the listing matches all criteria."""
+    def matches(self, listing: Any) -> bool:
+        """Return ``True`` when the listing satisfies all criteria."""
+
         for key, value in self.criteria.items():
             if getattr(listing, key, None) != value:
-                return
+                return False
+        return True
+
+    def notify(self, listing: Any) -> None:
+        """Send notifications if the listing matches all criteria."""
+        if not self.matches(listing):
+            return
 
         # Create a more detailed message
         title = getattr(listing, 'title', 'Unknown Property')


### PR DESCRIPTION
## Summary
- add a reusable `Notifier.matches` helper so matching logic can be reused outside of send-time
- queue pipeline notifications and flush them after the database commit to avoid coupling and run dispatch in a thread pool
- update the pipeline alert test to assert that notifications are queued for the dispatcher instead of sent inline

## Testing
- pytest tests/orchestration/test_pipeline_alerts.py

------
https://chatgpt.com/codex/tasks/task_e_68d78faca8bc8328a93309ab2da04533