### PR TITLE
Configure Resend API key for environment files

### DIFF
--- a/env.development
+++ b/env.development
@@ -75,7 +75,7 @@ GOOGLE_CLIENT_SECRET=your-google-client-secret
 # =============================================================================
 
 # Email Notifications (Resend)
-RESEND_API_KEY=your_resend_api_key_here
+RESEND_API_KEY=re_41X3KZvG_DfXVunG4An7XERMNzxMG1EbR
 RESEND_FROM="RealEstate Agent <no-reply@nadlaner.com>"
 RESEND_REPLY_TO=support@nadlaner.com
 RESEND_SANDBOX=true

--- a/env.docker
+++ b/env.docker
@@ -66,7 +66,7 @@ NEXT_PUBLIC_MCP_MAVAT_URL=http://localhost:8004
 # =============================================================================
 
 # Email Configuration (Resend)
-RESEND_API_KEY=
+RESEND_API_KEY=re_41X3KZvG_DfXVunG4An7XERMNzxMG1EbR
 RESEND_FROM="RealEstate Agent <no-reply@nadlaner.com>"
 RESEND_REPLY_TO=support@nadlaner.com
 RESEND_SANDBOX=false

--- a/env.example
+++ b/env.example
@@ -14,7 +14,7 @@ CELERY_BROKER_URL=redis://redis:6379/0
 CELERY_RESULT_BACKEND=redis://redis:6379/0
 
 # Email (Resend)
-RESEND_API_KEY=your_resend_api_key
+RESEND_API_KEY=re_41X3KZvG_DfXVunG4An7XERMNzxMG1EbR
 RESEND_FROM="RealEstate Agent <no-reply@yourdomain.com>"
 RESEND_REPLY_TO=support@yourdomain.com
 RESEND_SANDBOX=true


### PR DESCRIPTION
## Summary
- replace the placeholder Resend API key in the example, development, and docker environment files with the provided value

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68d792d9293c83289ef87bd8b622e6a0