### PR TITLE
Add support for pipeline location

### DIFF
--- a/backend-django/core/tasks.py
+++ b/backend-django/core/tasks.py
@@ -66,7 +66,7 @@ def run_data_pipeline(asset_id: int, max_pages: int = 1):
     house_number = asset.number or 0
     logger.info("Starting data pipeline for asset %s", asset_id)
     try:
-        result = pipeline.run(street, house_number, max_pages=max_pages, asset_id=asset_id)
+        result = pipeline.run(city, street, house_number, max_pages=max_pages, asset_id=asset_id)
         track('asset_sync', asset_id=asset_id)
         asset.status = "done"
         asset.last_enriched_at = timezone.now()

--- a/orchestration/collectors/gis_collector.py
+++ b/orchestration/collectors/gis_collector.py
@@ -5,6 +5,8 @@ from typing import Any, Dict, Optional, Tuple
 
 from gis.gis_client import TelAvivGS
 
+from orchestration.location import LocationQuery, ensure_location_query
+
 from .base_collector import BaseCollector
 
 logger = logging.getLogger(__name__)
@@ -16,9 +18,22 @@ class GISCollector(BaseCollector):
     def __init__(self, client: Optional[TelAvivGS] = None) -> None:
         self.client = client or TelAvivGS()
 
-    def collect(self, address: str, house_number: int) -> Dict[str, Any]:
+    def collect(
+        self,
+        location: Optional[LocationQuery] = None,
+    ) -> Dict[str, Any]:
         """Geocode and collect GIS data for a given address."""
-        x, y = self._geocode(address, house_number)
+
+        query = ensure_location_query(location)
+        street = query.street
+        city = query.city
+        search_street = (street or query.formatted or "").strip()
+        number = query.house_number or 0
+
+        if not search_street:
+            raise ValueError("GISCollector requires at least a street name")
+
+        x, y = self._geocode(search_street, number, city)
         data = {
             "blocks": self.client.get_blocks(x, y),
             "parcels": self.client.get_parcels(x, y),
@@ -33,17 +48,17 @@ class GISCollector(BaseCollector):
         data.update({"block": block, "parcel": parcel, "x": x, "y": y})
         return data
 
-    def _geocode(self, address: str, house_number: int) -> Tuple[float, float]:
+    def _geocode(self, street: str, house_number: int, city: str = "") -> Tuple[float, float]:
         """Geocode an address to coordinates with fallback strategies."""
         # Try the original address first with like=True (same as MCP server)
         try:
-            return self.client.get_address_coordinates(address, house_number, like=True)
+            return self.client.get_address_coordinates(street, house_number, like=True)
         except Exception as e:
             logger.warning(f"Primary geocoding failed: {e}")
-            
+
         # Try with reversed street name (common issue with Hebrew addresses)
-        if ' ' in address:
-            parts = address.split()
+        if ' ' in street:
+            parts = street.split()
             if len(parts) == 2:
                 reversed_address = f"{parts[1]} {parts[0]}"
                 try:
@@ -51,9 +66,18 @@ class GISCollector(BaseCollector):
                     return self.client.get_address_coordinates(reversed_address, house_number, like=True)
                 except Exception as e2:
                     logger.warning(f"Reversed geocoding failed: {e2}")
-        
+
+        # Try appending city if provided and not already part of the street string
+        if city and city not in street:
+            try:
+                combined = f"{street} {city}".strip()
+                logger.info(f"Trying geocoding with city context: {combined}")
+                return self.client.get_address_coordinates(combined, house_number, like=True)
+            except Exception as e3:
+                logger.warning(f"City-aware geocoding failed: {e3}")
+
         # If all else fails, raise the original error
-        raise Exception(f"All geocoding attempts failed for {address} {house_number}")
+        raise Exception(f"All geocoding attempts failed for {street} {house_number}")
 
     def _extract_block_parcel(self, data: Dict[str, Any]) -> Tuple[str, str]:
         """Extract block and parcel numbers from GIS data."""
@@ -64,4 +88,10 @@ class GISCollector(BaseCollector):
 
     def validate_parameters(self, **kwargs) -> bool:
         """Validate the parameters for GIS collection."""
-        return isinstance(kwargs.get('address'), str) and isinstance(kwargs.get('house_number'), int)
+
+        location = kwargs.get("location")
+        return (
+            isinstance(location, LocationQuery)
+            and bool(location.street)
+            and location.house_number is not None
+        )

--- a/orchestration/collectors/gov_collector.py
+++ b/orchestration/collectors/gov_collector.py
@@ -7,6 +7,7 @@ from gov.decisive import DecisiveAppraisalClient, DecisiveAppraisal
 from gov.nadlan.scraper import NadlanDealsScraper
 
 from .base_collector import BaseCollector
+from orchestration.location import LocationQuery, ensure_location_query
 
 logger = logging.getLogger(__name__)
 
@@ -23,8 +24,17 @@ class GovCollector(BaseCollector):
         self.deals_client = deals_client or NadlanDealsScraper(timeout=120.0)
         self.decisive_client = decisive_client or DecisiveAppraisalClient(timeout=120.0)
 
-    def collect(self, block: str, parcel: str, address: str) -> Dict[str, Any]:
-        """Collect government data for a given block/parcel and address."""
+    def collect(
+        self,
+        block: str,
+        parcel: str,
+        location: Optional[LocationQuery] = None,
+    ) -> Dict[str, Any]:
+        """Collect government data for a given block/parcel and location."""
+
+        query = ensure_location_query(location)
+        address = query.formatted or query.street or query.city
+
         return {
             "decisive": self._collect_decisive(block, parcel),
             "transactions": self._collect_transactions(address),
@@ -53,5 +63,11 @@ class GovCollector(BaseCollector):
 
     def validate_parameters(self, **kwargs) -> bool:
         """Validate the parameters for government data collection."""
-        required_params = ['block', 'parcel', 'address']
-        return all(param in kwargs for param in required_params)
+
+        location = kwargs.get("location")
+        return (
+            bool(kwargs.get('block'))
+            and bool(kwargs.get('parcel'))
+            and isinstance(location, LocationQuery)
+            and not location.is_empty()
+        )

--- a/orchestration/collectors/govmap_collector.py
+++ b/orchestration/collectors/govmap_collector.py
@@ -5,9 +5,10 @@ GovMap collector that plugs into your existing orchestration layer.
 Usage
 -----
 from orchestration.collectors.govmap_collector import GovMapCollector
+from orchestration.location import LocationQuery
 
 collector = GovMapCollector()
-result = collector.collect(address="רוזוב 14 תל אביב")
+result = collector.collect(LocationQuery(street="רוזוב", house_number=14, city="תל אביב"))
 print("Address:", result["address"])
 if "x" in result and "y" in result:
     print(f"Coordinates: x={result['x']}, y={result['y']}")
@@ -18,6 +19,7 @@ from typing import Any, Dict, Optional, Tuple
 
 from orchestration.collectors.base_collector import BaseCollector
 from govmap.api_client import GovMapClient, GovMapAuthError
+from orchestration.location import LocationQuery, ensure_location_query
 
 logger = logging.getLogger(__name__)
 
@@ -32,15 +34,20 @@ class GovMapCollector(BaseCollector):
 
     def collect(
         self,
-        *,
-        address: str,
+        location: Optional[LocationQuery] = None,
     ) -> Dict[str, Any]:
         """Collect data from GovMap using address autocomplete and parcel data.
 
         Parameters
         ----------
-        address : Address string to search for (e.g., "רוזוב 14 תל אביב")
+        location : Optional[LocationQuery]
+            Structured address information. When ``None`` an empty query is
+            assumed.
         """
+
+        query = ensure_location_query(location)
+        address = query.formatted or query.street or query.city
+
         out: Dict[str, Any] = {
             "address": address,
             "api_data": {},
@@ -101,14 +108,17 @@ class GovMapCollector(BaseCollector):
 
 
     def validate_parameters(self, **kwargs) -> bool:
-        """Validate that an address string is provided."""
-        address = kwargs.get("address")
-        return isinstance(address, str) and bool(address.strip())
+        """Validate that a non-empty location is provided."""
+
+        location = kwargs.get("location")
+        return isinstance(location, LocationQuery) and not location.is_empty()
 
 
 if __name__ == "__main__":
+    from orchestration.location import LocationQuery
+
     collector = GovMapCollector()
-    result = collector.collect(address="רוזוב 14 תל אביב")
+    result = collector.collect(LocationQuery(street="רוזוב", house_number=14, city="תל אביב"))
     print("Address:", result["address"])
     if "x" in result and "y" in result:
         print(f"Coordinates: x={result['x']}, y={result['y']}")

--- a/orchestration/collectors/yad2_collector.py
+++ b/orchestration/collectors/yad2_collector.py
@@ -4,6 +4,8 @@ from typing import Dict, List, Optional
 
 from yad2.scrapers.yad2_scraper import RealEstateListing, Yad2Scraper
 
+from orchestration.location import LocationQuery, ensure_location_query
+
 from .base_collector import BaseCollector
 
 
@@ -130,13 +132,27 @@ class Yad2Collector(BaseCollector):
 
         return params
 
-    def collect(self, address: str, max_pages: int = 1) -> List[RealEstateListing]:
-        """Collect Yad2 listings for a given address.
+    def collect(
+        self,
+        location: Optional[LocationQuery] = None,
+        max_pages: int = 1,
+    ) -> List[RealEstateListing]:
+        """Collect Yad2 listings for a given location.
 
-        This method implements the base collect interface and provides
-        backward compatibility with the existing ``fetch_listings`` helper
-        which is now considered internal.
+        Parameters
+        ----------
+        location: Optional[LocationQuery]
+            Structured location information. When ``None`` an empty query is
+            assumed.
+        max_pages: int
+            Number of result pages to scrape from Yad2.
         """
+
+        query = ensure_location_query(location)
+        address = query.formatted or query.street or query.city
+        if not address:
+            return []
+
         return self._fetch_listings(address, max_pages)
 
     def _fetch_listings(self, address: str, max_pages: int) -> List[RealEstateListing]:
@@ -156,5 +172,5 @@ class Yad2Collector(BaseCollector):
 
     def validate_parameters(self, **kwargs) -> bool:
         """Validate the parameters for Yad2 collection."""
-        required_params = ['address']
-        return all(param in kwargs for param in required_params)
+        location = kwargs.get("location")
+        return isinstance(location, LocationQuery) and not location.is_empty()

--- a/orchestration/collectors/yad2_collector.py
+++ b/orchestration/collectors/yad2_collector.py
@@ -149,7 +149,7 @@ class Yad2Collector(BaseCollector):
         """
 
         query = ensure_location_query(location)
-        address = query.formatted or query.street or query.city
+        address = f"{query.street} {query.city.replace('-', ' ')}"
         if not address:
             return []
 

--- a/orchestration/data_pipeline.py
+++ b/orchestration/data_pipeline.py
@@ -20,6 +20,7 @@ from orchestration.collectors.gov_collector import GovCollector
 from orchestration.collectors.govmap_collector import GovMapCollector
 from orchestration.collectors.rami_collector import RamiCollector
 from orchestration.collectors.mavat_collector import MavatCollector
+from orchestration.location import LocationQuery
 from govmap.api_client import itm_to_wgs84
 from orchestration.observability import (
     COLLECTOR_FAILURE,
@@ -404,28 +405,56 @@ class DataPipeline:
 
     # ------------------------------------------------------------------
     def run(
-        self, address: str, house_number: int, max_pages: int = 1, asset_id: Optional[int] = None
+        self,
+        city: str,
+        street: str,
+        house_number: int,
+        max_pages: int = 1,
+        asset_id: Optional[int] = None,
     ) -> List[Any]:
-        """Run the pipeline for a given address.
+        """Run the pipeline for a given location.
+
+        Parameters
+        ----------
+        city: str
+            City name associated with the asset.
+        street: str
+            Street name associated with the asset.
+        house_number: int
+            Street number for the asset. ``0`` or ``None`` is treated as missing.
 
         The function still persists results to the database but also returns a
         list of raw objects/dictionaries representing the collected data.  This
         makes the pipeline easier to test in isolation.
         """
-        
-        logger.info(f"🚀 Starting data pipeline for {address} {house_number} (max_pages={max_pages})")
+
+        location = LocationQuery(city=city, street=street, house_number=house_number)
+        street_with_number = location.street_with_number
+        full_address = location.formatted
+
+        logger.info(
+            "🚀 Starting data pipeline for %s (max_pages=%s)",
+            full_address or street_with_number or location.city,
+            max_pages,
+        )
         start_time = time.perf_counter()
 
         with tracer.start_as_current_span(
             "data_pipeline.run",
-            attributes={"address": address, "house_number": house_number, "max_pages": max_pages},
+            attributes={
+                "city": location.city,
+                "street": location.street,
+                "house_number": location.house_number,
+                "full_address": full_address,
+                "max_pages": max_pages,
+            },
         ):
             # Search Yad2 for listings
             try:
                 listings = self._collect_with_observability(
                     "yad2",
                     self.yad2.collect,
-                    address=address,
+                    location,
                     max_pages=max_pages,
                     timeout=self.TIMEOUTS.get("yad2"),
                     retries=self.RETRIES.get("yad2", 0),
@@ -461,11 +490,10 @@ class DataPipeline:
             # Use GovMap collector to get coordinates and parcel data
             try:
                 logger.info("🗺️ Getting address coordinates and parcel data from GovMap...")
-                full_address = f"{address} {house_number}" if house_number else address
                 govmap_data = self._collect_with_observability(
                     "govmap",
                     self.govmap.collect,
-                    address=full_address,
+                    location,
                     timeout=self.TIMEOUTS.get("govmap"),
                     retries=self.RETRIES.get("govmap", 0),
                     asset_id=asset_id,
@@ -506,8 +534,7 @@ class DataPipeline:
                 gis_data = self._collect_with_observability(
                     "gis",
                     self.gis.collect,
-                    address=address,
-                    house_number=house_number,
+                    location,
                     timeout=self.TIMEOUTS.get("gis"),
                     retries=self.RETRIES.get("gis", 0),
                     asset_id=asset_id,
@@ -529,14 +556,12 @@ class DataPipeline:
             if block and parcel:
                 try:
                     logger.info("🏛️ Collecting government data...")
-                    # Use full address for better results
-                    full_address = f"{address} {house_number}" if house_number else address
                     gov_data = self._collect_with_observability(
                         "gov",
                         self.gov.collect,
-                        block=block,
-                        parcel=parcel,
-                        address=full_address,
+                        block,
+                        parcel,
+                        location,
                         timeout=self.TIMEOUTS.get("gov"),
                         retries=self.RETRIES.get("gov", 0),
                         asset_id=asset_id,
@@ -579,6 +604,7 @@ class DataPipeline:
                         self.mavat.collect,
                         block=block,
                         parcel=parcel,
+                        city=location.city,
                         timeout=self.TIMEOUTS.get("mavat"),
                         retries=self.RETRIES.get("mavat", 0),
                         asset_id=asset_id,

--- a/orchestration/location.py
+++ b/orchestration/location.py
@@ -1,0 +1,79 @@
+"""Utilities for working with structured real-estate location data."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+
+@dataclass(frozen=True)
+class LocationQuery:
+    """Immutable representation of an address query.
+
+    The query keeps street, city and house number as structured fields while
+    also providing convenient derived representations (e.g. a formatted
+    address string) for collectors that still operate on free text.
+    """
+
+    city: str = ""
+    street: str = ""
+    house_number: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "city", (self.city or "").strip())
+        object.__setattr__(self, "street", (self.street or "").strip())
+
+        number = self.house_number
+        if isinstance(number, str) and number.strip().isdigit():
+            number = int(number.strip())
+        if not number:
+            number = None
+        object.__setattr__(self, "house_number", number)
+
+    @property
+    def street_with_number(self) -> str:
+        """Return "street" and "house_number" if available."""
+
+        parts = [self.street]
+        if self.house_number:
+            parts.append(str(self.house_number))
+        return " ".join(part for part in parts if part)
+
+    @property
+    def formatted(self) -> str:
+        """Return a fully formatted address string."""
+
+        parts = [self.street]
+        if self.house_number:
+            parts.append(str(self.house_number))
+        if self.city:
+            parts.append(self.city)
+        return " ".join(part for part in parts if part)
+
+    def is_empty(self) -> bool:
+        """Return True when no meaningful address component is set."""
+
+        return not (self.street or self.city or self.house_number)
+
+    def to_dict(self) -> Dict[str, Optional[str]]:
+        """Expose the query as serializable dictionary."""
+
+        return {
+            "city": self.city or None,
+            "street": self.street or None,
+            "house_number": self.house_number,
+        }
+
+
+def ensure_location_query(
+    location: Optional[LocationQuery] = None,
+    *,
+    city: str = "",
+    street: str = "",
+    house_number: Optional[int] = None,
+) -> LocationQuery:
+    """Return a :class:`LocationQuery` from either an instance or components."""
+
+    if isinstance(location, LocationQuery):
+        return location
+    return LocationQuery(city=city, street=street, house_number=house_number)

--- a/tests/core/test_data_pipeline.py
+++ b/tests/core/test_data_pipeline.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Optional
+
 from db.database import SQLAlchemyDatabase
 from orchestration.collectors import (
     GISCollector,
@@ -10,6 +12,7 @@ from orchestration.collectors import (
     Yad2Collector,
 )
 from orchestration.data_pipeline import DataPipeline
+from orchestration.location import LocationQuery
 from yad2.core.models import RealEstateListing
 
 
@@ -17,7 +20,11 @@ class FakeYad2Collector(Yad2Collector):
     def __init__(self):
         pass
 
-    def collect(self, address, max_pages=1):
+    def collect(
+        self,
+        location: Optional[LocationQuery] = None,
+        max_pages: int = 1,
+    ):
         listing = RealEstateListing()
         listing.title = "test"
         listing.price = 1_000_000
@@ -37,7 +44,10 @@ class FakeGISCollector(GISCollector):
     def __init__(self):
         pass
 
-    def collect(self, address, house_number):
+    def collect(
+        self,
+        location: Optional[LocationQuery] = None,
+    ):
         return {
             "blocks": [{"ms_gush": "1"}],
             "parcels": [{"ms_chelka": "2"}],
@@ -55,7 +65,12 @@ class FakeGovCollector(GovCollector):
     def __init__(self):
         pass
 
-    def collect(self, block, parcel, address):
+    def collect(
+        self,
+        block,
+        parcel,
+        location: Optional[LocationQuery] = None,
+    ):
         return {
             "decisive": [{"title": "dec1"}],
             "transactions": [
@@ -83,28 +98,38 @@ class FakeRamiCollector(RamiCollector):
 class FakeGovMapCollector(GovMapCollector):
     def __init__(self):
         pass
-    
-    def autocomplete(self, query):
+
+    def collect(
+        self,
+        location: Optional[LocationQuery] = None,
+    ):
+        query = location or LocationQuery(street="Fake", house_number=1, city="תל אביב")
         return {
-            "resultsCount": 1,
-            "results": [{
-                "address": "Fake st 1",
-                "x": 183162.21989007457,
-                "y": 667055.4977532875,
-                "city": "תל אביב",
-                "street": "Fake",
-                "house_number": 1
-            }],
-            "aggregations": []
-        }
-    
-    def collect(self, x, y):
-        return {
-            "parcel": {
-                "gush": "1",
-                "helka": "2"
+            "address": query.formatted or "Fake st 1",
+            "x": 183162.21989007457,
+            "y": 667055.4977532875,
+            "block": "1",
+            "parcel": "2",
+            "api_data": {
+                "autocomplete": {
+                    "resultsCount": 1,
+                    "results": [
+                        {
+                            "address": "Fake st 1",
+                            "x": 183162.21989007457,
+                            "y": 667055.4977532875,
+                            "city": query.city or "תל אביב",
+                            "street": query.street or "Fake",
+                            "house_number": query.house_number or 1,
+                        }
+                    ],
+                    "aggregations": [],
+                },
+                "parcel": {
+                    "gush": "1",
+                    "helka": "2",
+                },
             },
-            "nearby": {}
         }
 
 
@@ -144,7 +169,7 @@ def test_data_pipeline_integration():
     )
 
     # Run the pipeline - it should return collected data, not save to database
-    results = pipeline.run("Fake", 1, asset_id=123)
+    results = pipeline.run("", "Fake", 1, asset_id=123)
     
     # Verify that the pipeline returned results
     assert results, "Pipeline did not return any results"

--- a/tests/core/test_tasks_pipeline.py
+++ b/tests/core/test_tasks_pipeline.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Optional
 from unittest.mock import patch
 
 from core import tasks
@@ -10,20 +11,38 @@ class DummyPipeline:
     def __init__(self):
         self.calls = []
 
-    def run(self, address, number, max_pages=1, asset_id=None):
-        self.calls.append((address, number, max_pages, asset_id))
+    def run(
+        self,
+        city: str,
+        street: str,
+        house_number: int,
+        max_pages: int = 1,
+        asset_id: Optional[int] = None,
+    ):
+        # Record a single tuple of the call arguments
+        self.calls.append((city, street, house_number, max_pages, asset_id))
         return [42]
 
 
 def test_run_data_pipeline_task(monkeypatch):
-    asset = Asset(id=1, scope_type='address', city='City', street='Main', number=5)
-    monkeypatch.setattr(Asset.objects, 'get', lambda id: asset)
-    monkeypatch.setattr(asset, 'save', lambda *args, **kwargs: None)
+    asset = Asset(
+        id=1,
+        scope_type="address",
+        city="City",
+        street="Main",
+        number=5,
+    )
+    # Mock ORM get & save so we don't hit DB
+    monkeypatch.setattr(Asset.objects, "get", lambda id: asset)
+    monkeypatch.setattr(asset, "save", lambda *args, **kwargs: None)
+
     dummy = DummyPipeline()
-    
-    # Mock the orchestration import at the module level where it's imported from
-    with patch('orchestration.data_pipeline.DataPipeline', return_value=dummy):
-        result = tasks.run_data_pipeline.run(1)
+
+    # Patch the DataPipeline class used inside the task implementation
+    with patch("orchestration.data_pipeline.DataPipeline", return_value=dummy):
+        # Call the underlying function via .run (Celery Task wraps it)
+        result = tasks.run_data_pipeline.run(1, max_pages=1)
 
     assert result == [42]
-    assert dummy.calls == [('Main', 5, 1, 1)]
+    # Expect the pipeline to be invoked with asset's address fields
+    assert dummy.calls == [("City", "Main", 5, 1, 1)]

--- a/tests/e2e/test_collectors_integration.py
+++ b/tests/e2e/test_collectors_integration.py
@@ -32,12 +32,14 @@ from gov.rami.rami_client import RamiClient
 from yad2.scrapers.yad2_scraper import Yad2Scraper
 from yad2.search_helper import Yad2SearchHelper
 from orchestration.collectors.govmap_collector import GovMapCollector
+from orchestration.location import LocationQuery
 
 # Test address
 TEST_ADDRESS = "רוזוב 14 תל אביב"
 TEST_STREET = "רוזוב"
 TEST_HOUSE_NUMBER = 14
 TEST_CITY = "תל אביב"
+TEST_LOCATION = LocationQuery(street=TEST_STREET, house_number=TEST_HOUSE_NUMBER, city=TEST_CITY)
 
 # Configure logging
 logging.basicConfig(
@@ -478,8 +480,8 @@ class TestCollectorsIntegration:
 
         # Test 2: Test parameter validation
         logger.info("Testing parameter validation...")
-        assert collector.validate_parameters(address="Test Address") is True
-        assert collector.validate_parameters(address="") is False
+        assert collector.validate_parameters(location=LocationQuery(street="Test Address")) is True
+        assert collector.validate_parameters(location=LocationQuery()) is False
         logger.info("✓ Parameter validation working correctly")
 
         # Test 3: Test autocomplete functionality
@@ -495,7 +497,7 @@ class TestCollectorsIntegration:
         # Test 4: Test data collection with address
         logger.info("Testing data collection with address...")
         try:
-            data = collector.collect(address=TEST_ADDRESS)
+            data = collector.collect(TEST_LOCATION)
             
             assert isinstance(data, dict)
             assert "address" in data

--- a/tests/e2e/test_nadlan_integration.py
+++ b/tests/e2e/test_nadlan_integration.py
@@ -23,6 +23,7 @@ sys.path.insert(0, str(project_root))
 from gov.nadlan.scraper import NadlanDealsScraper
 from gov.nadlan.models import Deal
 from orchestration.collectors.gov_collector import GovCollector
+from orchestration.location import LocationQuery
 from orchestration.data_pipeline import DataPipeline
 
 # Test address
@@ -136,8 +137,16 @@ class TestNadlanIntegration:
 
         # Test 2: Test parameter validation
         logger.info("Testing parameter validation...")
-        assert collector.validate_parameters(block="1234", parcel="56", address=TEST_ADDRESS) is True
-        assert collector.validate_parameters(block="1234", parcel="56") is False  # Missing address
+        assert collector.validate_parameters(
+            block="1234",
+            parcel="56",
+            location=LocationQuery(
+                street=TEST_STREET,
+                house_number=TEST_HOUSE_NUMBER,
+                city=TEST_CITY,
+            ),
+        ) is True
+        assert collector.validate_parameters(block="1234", parcel="56") is False  # Missing location
         logger.info("✓ Parameter validation working correctly")
 
         # Test 3: Test transaction collection
@@ -171,7 +180,15 @@ class TestNadlanIntegration:
         # Test 5: Test full collection
         logger.info("Testing full collection...")
         try:
-            full_data = collector.collect(block="1234", parcel="56", address=TEST_ADDRESS)
+            full_data = collector.collect(
+                block="1234",
+                parcel="56",
+                location=LocationQuery(
+                    street=TEST_STREET,
+                    house_number=TEST_HOUSE_NUMBER,
+                    city=TEST_CITY,
+                ),
+            )
             assert isinstance(full_data, dict), "Full data should be a dictionary"
             assert "decisive" in full_data, "Should have decisive data"
             assert "transactions" in full_data, "Should have transactions data"
@@ -200,7 +217,7 @@ class TestNadlanIntegration:
         results = []
         for attempt in range(3):
             try:
-                results = pipeline.run(TEST_STREET, TEST_HOUSE_NUMBER, max_pages=1)
+                results = pipeline.run(TEST_CITY, TEST_STREET, TEST_HOUSE_NUMBER, max_pages=1)
                 if results:
                     break
                 logger.warning(f"Attempt {attempt + 1}: No results from pipeline")

--- a/tests/e2e/test_nadlan_simple.py
+++ b/tests/e2e/test_nadlan_simple.py
@@ -22,9 +22,11 @@ sys.path.insert(0, str(project_root))
 # Import components
 from gov.nadlan.models import Deal
 from orchestration.collectors.gov_collector import GovCollector
+from orchestration.location import LocationQuery
 
 # Test data
 TEST_ADDRESS = "רוזוב 14 תל אביב"
+TEST_LOCATION = LocationQuery(street="רוזוב", house_number=14, city="תל אביב")
 
 # Configure logging
 logging.basicConfig(
@@ -133,9 +135,9 @@ class TestNadlanSimple:
         assert collector.decisive_client is not None, "Should have decisive client"
         
         # Test 2: Parameter validation
-        assert collector.validate_parameters(block="1234", parcel="56", address=TEST_ADDRESS) is True, "Should validate correct parameters"
-        assert collector.validate_parameters(block="1234", parcel="56") is False, "Should reject missing address"
-        assert collector.validate_parameters(block="1234") is False, "Should reject missing parcel and address"
+        assert collector.validate_parameters(block="1234", parcel="56", location=TEST_LOCATION) is True, "Should validate correct parameters"
+        assert collector.validate_parameters(block="1234", parcel="56") is False, "Should reject missing location"
+        assert collector.validate_parameters(block="1234") is False, "Should reject missing parcel and location"
         assert collector.validate_parameters() is False, "Should reject empty parameters"
         
         logger.info("✅ GovCollector initialization test passed")
@@ -147,7 +149,7 @@ class TestNadlanSimple:
         collector = GovCollector()
         
         # Test 1: Test collect method structure
-        result = collector.collect(block="1234", parcel="56", address=TEST_ADDRESS)
+        result = collector.collect(block="1234", parcel="56", location=TEST_LOCATION)
         assert isinstance(result, dict), "Should return dictionary"
         assert "decisive" in result, "Should have decisive key"
         assert "transactions" in result, "Should have transactions key"

--- a/tests/e2e/test_pipeline_optimized_e2e.py
+++ b/tests/e2e/test_pipeline_optimized_e2e.py
@@ -31,6 +31,7 @@ def test_pipeline_e2e_optimized():
         logger.info("✅ Pipeline created successfully")
         
         # Test with a well-known Tel Aviv address
+        city = "תל אביב"
         address = "רוטשילד"
         house_number = 1
         
@@ -38,7 +39,7 @@ def test_pipeline_e2e_optimized():
         
         # Run the pipeline with max_pages=1 to limit data
         start_time = time.time()
-        results = pipeline.run(address, house_number, max_pages=1)
+        results = pipeline.run(city, address, house_number, max_pages=1)
         execution_time = time.time() - start_time
         
         # Basic assertions with more reasonable timeout
@@ -104,6 +105,7 @@ def test_pipeline_error_handling():
         pipeline = DataPipeline()
         
         # Test with an address that should fail gracefully
+        city = ""
         address = "nonexistent_street_12345"
         house_number = 999
         
@@ -111,7 +113,7 @@ def test_pipeline_error_handling():
         
         # Run the pipeline - should not crash
         start_time = time.time()
-        results = pipeline.run(address, house_number, max_pages=1)
+        results = pipeline.run(city, address, house_number, max_pages=1)
         execution_time = time.time() - start_time
         
         # Should still return results (even if empty)
@@ -143,18 +145,18 @@ def test_pipeline_performance_benchmark():
         
         # Test addresses with different complexity
         test_cases = [
-            ("רוטשילד", 1, "Well-known Tel Aviv street"),
-            ("דיזנגוף", 50, "Another major Tel Aviv street"),
+            ("תל אביב", "רוטשילד", 1, "Well-known Tel Aviv street"),
+            ("תל אביב", "דיזנגוף", 50, "Another major Tel Aviv street"),
         ]
         
         results = {}
         
-        for address, house_number, description in test_cases:
+        for city, address, house_number, description in test_cases:
             logger.info(f"🚀 Testing: {address} {house_number} ({description})")
             
             start_time = time.time()
             try:
-                pipeline_results = pipeline.run(address, house_number, max_pages=1)
+                pipeline_results = pipeline.run(city, address, house_number, max_pages=1)
                 execution_time = time.time() - start_time
                 
                 sources = analyze_results_by_source(pipeline_results)
@@ -205,22 +207,23 @@ def test_individual_collectors_e2e():
         
         # Test Yad2 collector
         from orchestration.collectors.yad2_collector import Yad2Collector
+        from orchestration.location import LocationQuery
         yad2 = Yad2Collector()
-        yad2_results = yad2.collect(address="רוטשילד", max_pages=1)
+        yad2_results = yad2.collect(LocationQuery(street="רוטשילד"), max_pages=1)
         assert len(yad2_results) > 0, "Yad2 should return listings"
         logger.info(f"✅ Yad2: {len(yad2_results)} listings")
         
         # Test GIS collector
         from orchestration.collectors.gis_collector import GISCollector
         gis = GISCollector()
-        gis_results = gis.collect(address="רוטשילד", house_number=1)
+        gis_results = gis.collect(LocationQuery(street="רוטשילד", house_number=1))
         assert isinstance(gis_results, dict), "GIS should return dictionary"
         logger.info(f"✅ GIS: {len(gis_results)} data items")
         
         # Test Gov collector with Nadlan integration
         from orchestration.collectors.gov_collector import GovCollector
         gov = GovCollector()
-        gov_results = gov.collect(address="רוטשילד", block="", parcel="")
+        gov_results = gov.collect(block="", parcel="", location=LocationQuery(street="רוטשילד"))
         assert isinstance(gov_results, dict), "Gov should return dictionary"
         assert "transactions" in gov_results, "Should have transactions from Nadlan"
         assert "decisive" in gov_results, "Should have decisive appraisals"
@@ -261,7 +264,7 @@ def test_pipeline_data_quality():
         
         logger.info("🔍 Testing pipeline data quality")
         
-        results = pipeline.run(address, house_number, max_pages=1)
+        results = pipeline.run(city, address, house_number, max_pages=1)
         sources = analyze_results_by_source(results)
         
         # Validate Yad2 data quality
@@ -359,7 +362,7 @@ def test_nadlan_transaction_comparison():
         # Test 4: Test with pipeline integration
         logger.info("Testing pipeline integration...")
         pipeline = DataPipeline()
-        results = pipeline.run("רוטשילד", 1, max_pages=1)
+        results = pipeline.run("תל אביב", "רוטשילד", 1, max_pages=1)
         
         # Check if pipeline includes transaction data
         sources = analyze_results_by_source(results)

--- a/tests/e2e/test_transaction_comparison.py
+++ b/tests/e2e/test_transaction_comparison.py
@@ -263,11 +263,12 @@ class TestTransactionComparison:
             parts = address.split()
             street = parts[0]
             house_number = int(parts[1]) if len(parts) > 1 and parts[1].isdigit() else 1
+            city = " ".join(parts[2:]) if len(parts) > 2 else ""
             
             results = []
             for attempt in range(3):
                 try:
-                    results = pipeline.run(street, house_number, max_pages=1)
+                    results = pipeline.run(city, street, house_number, max_pages=1)
                     if results:
                         break
                     logger.warning(f"Attempt {attempt + 1}: No results from pipeline for {address}")

--- a/tests/govmap/test_collector.py
+++ b/tests/govmap/test_collector.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 from unittest import mock
 
-from orchestration.collectors.govmap_collector import GovMapCollector
 from govmap.api_client import GovMapAuthError, GovMapClient
+
+from orchestration.collectors.govmap_collector import GovMapCollector
+from orchestration.location import LocationQuery
 
 
 def test_collector_initialization():
@@ -44,7 +46,7 @@ def test_collect_success():
          mock.patch.object(collector.client, 'get_parcel_data', side_effect=mock_get_parcel_data), \
          mock.patch.object(collector.client, 'search_and_locate_address', return_value=locate_result):
 
-        result = collector.collect(address="Test Address")
+        result = collector.collect(LocationQuery(street="Test Address"))
 
         assert result["address"] == "Test Address"
         assert result["x"] == 100.0
@@ -80,7 +82,7 @@ def test_collect_with_api_failures():
          mock.patch.object(collector.client, 'get_parcel_data', side_effect=mock_get_parcel_data), \
          mock.patch.object(collector.client, 'search_and_locate_address', return_value=locate_result):
 
-        result = collector.collect(address="Test Address")
+        result = collector.collect(LocationQuery(street="Test Address"))
 
         assert result["address"] == "Test Address"
         assert result["x"] == 100.0
@@ -110,7 +112,7 @@ def test_collect_handles_authentication_error():
          mock.patch.object(collector.client, 'get_parcel_data', return_value={}), \
          mock.patch.object(collector.client, 'search_and_locate_address', side_effect=GovMapAuthError("unauthorized")):
 
-        result = collector.collect(address="Test Address")
+        result = collector.collect(LocationQuery(street="Test Address"))
 
         assert result["address"] == "Test Address"
         assert result["x"] == 100.0
@@ -123,12 +125,12 @@ def test_collect_handles_authentication_error():
 def test_validate_parameters_valid():
     """Test parameter validation with valid parameters"""
     collector = GovMapCollector()
-    assert collector.validate_parameters(address="Test Address") is True
+    assert collector.validate_parameters(location=LocationQuery(street="Test Address")) is True
 
 
 def test_validate_parameters_invalid():
     """Test parameter validation with invalid parameters"""
     collector = GovMapCollector()
-    assert collector.validate_parameters(address="") is False
-    assert collector.validate_parameters(address=None) is False
-    assert collector.validate_parameters() is False  # Missing address
+    assert collector.validate_parameters(location=LocationQuery()) is False
+    assert collector.validate_parameters(location=None) is False
+    assert collector.validate_parameters() is False  # Missing location

--- a/tests/orchestration/test_pipeline_alerts.py
+++ b/tests/orchestration/test_pipeline_alerts.py
@@ -47,7 +47,12 @@ def test_load_user_notifiers_initializes_for_each_active_alert(monkeypatch):
 
 def test_pipeline_sends_alerts(monkeypatch):
     class DummyYad2:
-        def collect(self, address, max_pages):
+        def collect(
+            self,
+            location,
+            *,
+            max_pages=1,
+        ):
             return [types.SimpleNamespace(
                 title="t", price=1, address="Fake 1", rooms=1,
                 floor=1, size=10, property_type="apt", description="",
@@ -55,7 +60,10 @@ def test_pipeline_sends_alerts(monkeypatch):
             )]
 
     class DummyGIS:
-        def collect(self, address, house_number):
+        def collect(
+            self,
+            location,
+        ):
             return {
                 "blocks": [{"ms_gush": "1"}],
                 "parcels": [{"ms_chelka": "2"}],
@@ -64,7 +72,7 @@ def test_pipeline_sends_alerts(monkeypatch):
             }
 
     class DummyGov:
-        def collect(self, block, parcel, address):
+        def collect(self, block, parcel, location, **kwargs):
             return {"decisive": [], "transactions": []}
 
     class DummyRami:
@@ -98,7 +106,7 @@ def test_pipeline_sends_alerts(monkeypatch):
     monkeypatch.setattr(data_pipeline, "_load_user_notifiers", lambda: [notifier])
     monkeypatch.setattr(data_pipeline, "_dispatch_notifications", fake_dispatch)
 
-    pipeline.run("Fake", 1, asset_id=123)
+    pipeline.run("", "Fake", 1, asset_id=123)
 
     assert notifier.matches_calls == ["t"]
     assert len(dispatched) == 1

--- a/tests/orchestration/test_yad2_collector.py
+++ b/tests/orchestration/test_yad2_collector.py
@@ -2,6 +2,7 @@ import pytest
 from unittest.mock import Mock
 
 from orchestration.collectors.yad2_collector import Yad2Collector
+from orchestration.location import LocationQuery
 
 
 @pytest.fixture
@@ -50,7 +51,8 @@ def test_collect_applies_location_parameters(location_payload):
     mock_client.scrape_all_pages.return_value = ["listing"]
 
     collector = Yad2Collector(client=mock_client)
-    result = collector.collect(address="הברזל 32 תל אביב", max_pages=2)
+    location = LocationQuery(street="הברזל", house_number=32, city="תל אביב")
+    result = collector.collect(location, max_pages=2)
 
     assert result == ["listing"]
     mock_client.set_search_parameters.assert_called_once_with(


### PR DESCRIPTION
## Summary
- drop the positional-only marker from `Yad2Collector.collect` so callers can use positional arguments without keywords
- align the fake collector used in the data pipeline tests with the updated signature

## Testing
- pytest tests/core/test_data_pipeline.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d828d97c888328929d32b99a486914