### PR TITLE
Support Google AI Studio key for Gemini marketing messages

### DIFF
--- a/backend-django/broker_backend/settings.py
+++ b/backend-django/broker_backend/settings.py
@@ -25,9 +25,11 @@ ALLOWED_HOSTS = config('ALLOWED_HOSTS', default='localhost,127.0.0.1,testserver'
 LLM_DEFAULT_PROVIDER = os.getenv("LLM_DEFAULT_PROVIDER", "gemini")
 LLM_ALLOW_OVERRIDE = os.getenv("LLM_ALLOW_OVERRIDE", "true").lower() == "true"
 
-# Gemini
-GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
-GEMINI_MODEL = os.getenv("GEMINI_MODEL", "gemini-2.5-pro")
+# Gemini / Google AI Studio
+GOOGLE_API_KEY = os.getenv("GOOGLE_API_KEY")
+GOOGLE_MODEL = os.getenv("GOOGLE_MODEL")
+GEMINI_API_KEY = os.getenv("GEMINI_API_KEY") or GOOGLE_API_KEY
+GEMINI_MODEL = os.getenv("GEMINI_MODEL") or GOOGLE_MODEL or "gemini-2.5-pro"
 
 # OpenAI
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")

--- a/backend-django/core/llm/providers/gemini.py
+++ b/backend-django/core/llm/providers/gemini.py
@@ -14,10 +14,15 @@ class GeminiAdapter(LLMClient):
     provider = "gemini"
 
     def __init__(self) -> None:
-        if not settings.GEMINI_API_KEY:
+        api_key = settings.GEMINI_API_KEY or getattr(settings, "GOOGLE_API_KEY", None)
+        if not api_key:
             raise ValueError("GEMINI_API_KEY is not configured")
-        genai.configure(api_key=settings.GEMINI_API_KEY)
-        self.model_name = settings.GEMINI_MODEL
+        genai.configure(api_key=api_key)
+        self.model_name = (
+            settings.GEMINI_MODEL
+            or getattr(settings, "GOOGLE_MODEL", None)
+            or "gemini-2.5-pro"
+        )
 
     def _get_model(
         self, json_mode: bool, schema: Optional[Dict[str, Any]] | None = None

--- a/env.development
+++ b/env.development
@@ -219,4 +219,6 @@ CACHE_LOCATION=redis://localhost:6379/1
 # =============================================================================
 # LLM INTEGRATION
 # =============================================================================
-GEMINI_API_KEY = AIzaSyBGEoU7k_ZWv9TCI9d5jJlilLVJdUHTeMQ
+GEMINI_API_KEY=your_gemini_api_key
+# You may also use GOOGLE_API_KEY if copying from Google AI Studio dashboard.
+# GOOGLE_API_KEY=your_gemini_api_key

--- a/env.example
+++ b/env.example
@@ -49,6 +49,13 @@ MCP_GIS_PORT=8003
 MCP_MAVAT_PORT=8004
 
 # Optional: External API Keys
+# Gemini / Google AI Studio
+GEMINI_API_KEY=your_gemini_api_key
+# Alternatively you can set GOOGLE_API_KEY if you are copying the key directly
+# from Google AI Studio.
+# GEMINI_MODEL=gemini-1.5-pro
+# GOOGLE_API_KEY=your_gemini_api_key
+# GOOGLE_MODEL=gemini-1.5-pro
 # YAD2_API_KEY=your_yad2_api_key
 # GOV_RAMI_API_KEY=your_gov_rami_api_key
 # GIS_API_KEY=your_gis_api_key

--- a/tests/core/test_llm_factory.py
+++ b/tests/core/test_llm_factory.py
@@ -1,0 +1,25 @@
+from django.test import override_settings
+
+from core.llm.factory import create_llm_client
+from core.llm.providers.gemini import GeminiAdapter
+
+
+@override_settings(
+    GEMINI_API_KEY=None,
+    GEMINI_MODEL=None,
+    GOOGLE_API_KEY="google-key",
+    GOOGLE_MODEL="gemini-1.5-pro",
+)
+def test_create_llm_client_uses_google_api_key(monkeypatch):
+    captured = {}
+
+    def fake_configure(*, api_key):
+        captured["api_key"] = api_key
+
+    monkeypatch.setattr("google.generativeai.configure", fake_configure)
+
+    client = create_llm_client("gemini")
+
+    assert isinstance(client, GeminiAdapter)
+    assert captured["api_key"] == "google-key"
+    assert client.model_name == "gemini-1.5-pro"


### PR DESCRIPTION
## Summary
- allow the Gemini adapter to fall back to GOOGLE_API_KEY/GOOGLE_MODEL when configured from Google AI Studio
- document the Google AI Studio key support in the sample environment files
- add a regression test covering the fallback configuration for the Gemini client

## Testing
- pytest tests/core/test_llm_factory.py -q
- pytest tests/core/test_share_message.py -q

------
https://chatgpt.com/codex/tasks/task_e_68da4b53c5488328b2f02e96699f2c67