### PR TITLE
Ensure fake pipeline collectors accept optional block/parcel arguments

### DIFF
--- a/backend-django/tests/core/test_data_pipeline.py
+++ b/backend-django/tests/core/test_data_pipeline.py
@@ -47,6 +47,9 @@ class FakeGISCollector(GISCollector):
     def collect(
         self,
         location: Optional[LocationQuery] = None,
+        *,
+        block: Optional[str] = None,
+        parcel: Optional[str] = None,
     ):
         return {
             "blocks": [{"ms_gush": "1"}],
@@ -102,6 +105,9 @@ class FakeGovMapCollector(GovMapCollector):
     def collect(
         self,
         location: Optional[LocationQuery] = None,
+        *,
+        block: Optional[str] = None,
+        parcel: Optional[str] = None,
     ):
         query = location or LocationQuery(street="Fake", house_number=1, city="תל אביב")
         return {

--- a/backend-django/tests/core/test_data_pipeline.py
+++ b/backend-django/tests/core/test_data_pipeline.py
@@ -47,7 +47,6 @@ class FakeGISCollector(GISCollector):
     def collect(
         self,
         location: Optional[LocationQuery] = None,
-        *,
         block: Optional[str] = None,
         parcel: Optional[str] = None,
     ):
@@ -105,7 +104,6 @@ class FakeGovMapCollector(GovMapCollector):
     def collect(
         self,
         location: Optional[LocationQuery] = None,
-        *,
         block: Optional[str] = None,
         parcel: Optional[str] = None,
     ):


### PR DESCRIPTION
## Summary
- allow the fake GIS collector in the data pipeline integration test to accept optional block and parcel keyword arguments
- allow the fake GovMap collector in the integration test to accept optional block and parcel keyword arguments so the pipeline can aggregate multiple sources

## Testing
- pytest backend-django/tests/core/test_data_pipeline.py::test_data_pipeline_integration

------
https://chatgpt.com/codex/tasks/task_e_68e2c82dc3f08328a0a4ef4ef5486bc7