### PR TITLE
Fix Docker build context for backend service

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -209,7 +209,7 @@ services:
   - key: ALLOWED_HOSTS
     sync: false
   region: oregon
-  dockerContext: .
+  dockerContext: ../
   dockerfilePath: ./Dockerfile
   autoDeployTrigger: commit
   rootDir: backend-django


### PR DESCRIPTION
## Summary
- update the Render configuration so the backend Docker build uses the repository root as its context

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2e269884083289b4487e87f49cf73