### PR TITLE
Fix boot script path in backend Dockerfile

### DIFF
--- a/backend-django/Dockerfile
+++ b/backend-django/Dockerfile
@@ -48,7 +48,7 @@ COPY backend-django /app/backend-django
 
 # Supervisor config + boot script
 RUN cp /app/backend-django/deploy/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
-RUN chmod +x /backend-django/app/deploy/boot.sh
+RUN chmod +x /app/backend-django/deploy/boot.sh
 
 # Create a non-root user
 RUN useradd --create-home --shell /bin/bash app \


### PR DESCRIPTION
## Summary
- correct the boot script path used during image build so the file can be found

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2f48bb4fc832881186ea18f764bb9