### PR TITLE
Chore: Fix django backend container 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -40,13 +40,14 @@ ENV/
 env.bak/
 venv.bak/
 
-# Node.js
+# Node.js / Frontend
 node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .npm
 .yarn-integrity
+realestate-broker-ui/
 
 # Next.js
 .next/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,86 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim AS base
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
+WORKDIR /app
+
+# Install system dependencies required for Django, Celery, Playwright and geo/GIS collectors
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    gcc \
+    g++ \
+    libpq-dev \
+    supervisor \
+    curl \
+    # Playwright/Chromium runtime deps
+    libnss3 \
+    libatk-bridge2.0-0 \
+    libxcb1 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxfixes3 \
+    libxrender1 \
+    libxtst6 \
+    libxi6 \
+    libdbus-1-3 \
+    libxrandr2 \
+    libasound2 \
+    libatk1.0-0 \
+    libgtk-3-0 \
+    libdrm2 \
+    libgbm1 \
+    libcairo2 \
+    libpango-1.0-0 \
+    libpangoft2-1.0-0 \
+    libpangocairo-1.0-0 \
+    libatspi2.0-0 \
+    libgobject-2.0-0 \
+    libglib2.0-0 \
+    libgdk-pixbuf-2.0-0 \
+    libffi-dev \
+    libfreetype6 \
+    fontconfig \
+    fonts-noto-core \
+    # GIS/geo stack dependencies used by collectors
+    gdal-bin \
+    libgdal-dev \
+    libgeos-dev \
+    proj-bin \
+    libproj-dev \
+    libspatialindex-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies for backend + pipeline + collectors
+COPY requirements-production.txt /tmp/requirements-production.txt
+RUN python -m pip install --upgrade pip \
+    && pip install --no-cache-dir -r /tmp/requirements-production.txt
+
+# Preinstall Chromium for Playwright collectors
+RUN mkdir -p "$PLAYWRIGHT_BROWSERS_PATH" \
+    && python -m playwright install chromium
+
+# Copy the full repository so orchestration/collector modules are available to Django
+COPY . /app
+
+# Prepare supervisor configuration and boot script
+RUN mkdir -p /etc/supervisor/conf.d \
+    && cp backend-django/deploy/supervisord.conf /etc/supervisor/conf.d/supervisord.conf \
+    && chmod +x backend-django/deploy/boot.sh
+
+# Ensure runtime user has access to application files and Playwright browsers
+RUN useradd --create-home --shell /bin/bash app \
+    && chown -R app:app /app "$PLAYWRIGHT_BROWSERS_PATH"
+
+USER app
+
+# Keep the full repository on the PYTHONPATH for Django, orchestration, and collectors
+ENV PYTHONPATH=/app:/app/backend-django
+WORKDIR /app
+
+EXPOSE 8000
+
+CMD ["backend-django/deploy/boot.sh"]

--- a/backend-django/deploy/boot.sh
+++ b/backend-django/deploy/boot.sh
@@ -1,4 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
+# Resolve the Django project directory relative to this script so we can
+# reliably locate it even if the container root differs (e.g. /app/backend-django
+# or /app/realestate-agent/backend-django).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [[ -d "$REPO_ROOT/backend-django" ]]; then
+  DJANGO_DIR="$REPO_ROOT/backend-django"
+elif [[ -d "$REPO_ROOT" && -f "$REPO_ROOT/manage.py" ]]; then
+  DJANGO_DIR="$REPO_ROOT"
+elif [[ -d "/app/backend-django" ]]; then
+  DJANGO_DIR="/app/backend-django"
+elif [[ -d "/app" && -f "/app/manage.py" ]]; then
+  DJANGO_DIR="/app"
+else
+  echo "Unable to locate Django project directory" >&2
+  ls -al "$REPO_ROOT" || true
+  exit 1
+fi
+
+cd "$DJANGO_DIR"
+
+export DJANGO_DIR
+
 python manage.py migrate --noinput
 exec supervisord -n -c /etc/supervisor/conf.d/supervisord.conf

--- a/backend-django/deploy/supervisord.conf
+++ b/backend-django/deploy/supervisord.conf
@@ -7,8 +7,8 @@ pidfile=/tmp/supervisord.pid
 childlogdir=/tmp
 
 [program:gunicorn]
-directory=/app
-command=gunicorn broker_backend.wsgi:application --bind 0.0.0.0:8000 --workers 1 --timeout 120
+directory=%(ENV_DJANGO_DIR)s
+command=gunicorn broker_backend.wsgi:application --chdir %(ENV_DJANGO_DIR)s --bind 0.0.0.0:8000 --workers 1 --timeout 120
 autostart=true
 autorestart=true
 stopsignal=TERM
@@ -20,8 +20,8 @@ stderr_logfile_maxbytes=0
 environment=PYTHONUNBUFFERED="1"
 
 [program:celery]
-directory=/app
-command=celery -A broker_backend worker -l info -c 2
+directory=%(ENV_DJANGO_DIR)s
+command=celery --workdir %(ENV_DJANGO_DIR)s -A broker_backend worker -l info -c 2
 autostart=true
 autorestart=true
 stopsignal=TERM

--- a/render.yaml
+++ b/render.yaml
@@ -212,7 +212,6 @@ services:
   dockerContext: .
   dockerfilePath: ./Dockerfile
   autoDeployTrigger: commit
-  rootDir: backend-django
   previews:
     generation: manual
 - type: web

--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -1,0 +1,9 @@
+# Production requirements for the backend container including data pipeline and collectors
+-r backend-django/requirements.txt
+-r db/requirements.txt
+-r orchestration/requirements.txt
+-r gov/requirements.txt
+-r govmap/requirements.txt
+-r gis/requirements.txt
+-r yad2/requirements.txt
+-r mavat/requirements.txt


### PR DESCRIPTION
## Summary
- export the resolved Django project directory from the boot script for downstream processes
- update the supervisor gunicorn and celery programs to use the absolute Django path provided by the boot script

## Testing
- pytest backend-django/tests/core/test_tasks_pipeline.py::test_run_data_pipeline_task -q

------
https://chatgpt.com/codex/tasks/task_e_68e396dc61b48328b0db4cd7ba4bce3c