### PR TITLE
Add Nadlaner legal pages and footer summary

### DIFF
--- a/nadlaner-marketing/index.html
+++ b/nadlaner-marketing/index.html
@@ -509,7 +509,7 @@
   <!-- FOOTER -->
   <footer class="border-t border-neutral-200 py-10 bg-neutral-50">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-      <div class="grid md:grid-cols-4 gap-8 mb-8">
+      <div class="grid md:grid-cols-5 gap-8 mb-8">
         <div>
           <div class="flex items-center gap-2 mb-3">
             <img src="/favicon-32.png" alt="לוגו נדל״נר" width="32" height="32" loading="lazy" decoding="async" class="w-6 h-6" />
@@ -529,9 +529,18 @@
         <div>
           <h4 class="font-semibold mb-3">קישורים</h4>
           <ul class="space-y-2 text-sm text-neutral-600">
-            <li><a href="https://app.nadlaner.com/terms-of-use" class="hover:underline">תנאי שימוש</a></li>
-            <li><a href="https://app.nadlaner.com/terms-of-use" class="hover:underline">מדיניות פרטיות</a></li>
+            <li><a href="/terms-of-use.html" class="hover:underline">תנאי שימוש</a></li>
+            <li><a href="/privacy-policy.html" class="hover:underline">מדיניות פרטיות</a></li>
             <li><a href="https://app.nadlaner.com/contact" class="hover:underline">צור קשר</a></li>
+          </ul>
+        </div>
+        <div>
+          <h4 class="font-semibold mb-3">🧭 תקציר</h4>
+          <ul class="space-y-2 text-sm text-neutral-600">
+            <li>אוספים רק פרטי קשר בסיסיים ונתוני שימוש לשיפור חוויה.</li>
+            <li>לא משתפים מידע אישי ללא הצדקה.</li>
+            <li>ניתן לבקש לעיין, לעדכן או למחוק פרטים בכל עת.</li>
+            <li>שימוש באתר מהווה הסכמה לתנאים ולמדיניות.</li>
           </ul>
         </div>
         <div>

--- a/nadlaner-marketing/privacy-policy.html
+++ b/nadlaner-marketing/privacy-policy.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="he" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>מדיניות פרטיות Nadlaner</title>
+  <meta name="description" content="מדיניות הפרטיות של Nadlaner, מעודכנת ל-6 באוקטובר 2025, כולל פירוט המידע הנאסף והשימוש בו." />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+  <link rel="canonical" href="https://www.nadlaner.com/privacy-policy" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, "Inter", sans-serif; }
+    :focus-visible { outline: 2px solid #0ea5e9; outline-offset: 2px; }
+  </style>
+</head>
+<body class="bg-neutral-50 text-neutral-900">
+  <header class="border-b border-neutral-200 bg-white">
+    <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
+      <a href="/" class="flex items-center gap-2">
+        <img src="/favicon-32.png" alt="לוגו נדל״נר" width="32" height="32" loading="lazy" decoding="async" class="w-7 h-7" />
+        <span class="font-bold text-teal-600">נדל"נר</span>
+      </a>
+      <a href="/" class="text-sm text-teal-600 hover:underline">חזרה לדף הבית</a>
+    </div>
+  </header>
+
+  <main class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-10 space-y-8">
+    <section class="space-y-4">
+      <h1 class="text-3xl font-bold">🔒 מדיניות פרטיות</h1>
+      <p class="text-sm text-neutral-500">עודכן לאחרונה: 6 באוקטובר 2025</p>
+      <p>המסמך מפרט כיצד Nadlaner אוסף, משתמש, שומר ומגן על מידע אישי של משתמשים.</p>
+    </section>
+
+    <section class="space-y-3">
+      <h2 class="text-2xl font-semibold">1. סוגי המידע שנאספים</h2>
+      <p>בעת שימושך באתר ייתכן שנאסוף את המידע הבא:</p>
+      <ul class="list-disc pr-5 space-y-2">
+        <li>פרטים מזהים: שם מלא, כתובת דוא״ל, מספר טלפון.</li>
+        <li>נתוני שימוש: עמודים בהם ביקרת, תאריך ושעת כניסה, מיקום משוער, מזהה דפדפן.</li>
+        <li>Cookies או טכנולוגיות דומות לצורך שיפור חוויית המשתמש וניתוח סטטיסטי.</li>
+      </ul>
+    </section>
+
+    <section class="space-y-3">
+      <h2 class="text-2xl font-semibold">2. מטרות השימוש במידע</h2>
+      <p>המידע משמש ל-:</p>
+      <ul class="list-disc pr-5 space-y-2">
+        <li>ניהול ושיפור חוויית המשתמש.</li>
+        <li>מענה לפניות ושירות לקוחות.</li>
+        <li>שליחת עדכונים, מבצעים או חומרים שיווקיים (בהתאם להסכמתך).</li>
+        <li>עמידה בדרישות חוקיות ואבטחת האתר.</li>
+      </ul>
+    </section>
+
+    <section class="space-y-3">
+      <h2 class="text-2xl font-semibold">3. שיתוף מידע עם צדדים שלישיים</h2>
+      <p>אנו עשויים לשתף מידע עם:</p>
+      <ul class="list-disc pr-5 space-y-2">
+        <li>ספקי שירותי אירוח ותשתית (כגון Render, Vercel, Cloudflare).</li>
+        <li>ספקי ניתוח נתונים (Google Analytics או מקבילים).</li>
+        <li>רשויות ממשלתיות או גופים ציבוריים (כגון govmap, רמ״י, nadlan.gov, MAVAT) לצורך הצגת מידע רלוונטי בלבד.</li>
+      </ul>
+      <p>לא נמכור או נעביר מידע אישי לצדדים שלישיים למטרות מסחריות.</p>
+    </section>
+
+    <section class="space-y-3">
+      <h2 class="text-2xl font-semibold">4. אבטחת מידע</h2>
+      <p>ננקטים אמצעי אבטחה סבירים (טכנולוגיים וארגוניים) לשמירת המידע האישי מפני גישה, שינוי או מחיקה בלתי מורשית. עם זאת, אין מערכת מאובטחת לחלוטין, והמשתמש מצהיר כי הוא מודע לכך.</p>
+    </section>
+
+    <section class="space-y-3">
+      <h2 class="text-2xl font-semibold">5. שמירת מידע</h2>
+      <p>המידע האישי יישמר כל עוד נדרש למטרות שלשמן נאסף, או בהתאם לחוק. משתמש רשאי לפנות ולבקש מחיקה או עדכון של פרטיו.</p>
+    </section>
+
+    <section class="space-y-3">
+      <h2 class="text-2xl font-semibold">6. פנייה בנושאי פרטיות</h2>
+      <p>ניתן לפנות אלינו בכל עת בכתובת דוא״ל: <a href="mailto:privacy@nadlaner.com" class="text-teal-600 hover:underline">privacy@nadlaner.com</a></p>
+    </section>
+
+    <section class="space-y-3">
+      <h2 class="text-2xl font-semibold">7. שינויים במדיניות</h2>
+      <p>מדיניות זו עשויה להתעדכן מעת לעת. גרסה מעודכנת תפורסם באתר ותיכנס לתוקף עם פרסומה.</p>
+    </section>
+
+    <section class="space-y-3">
+      <h2 class="text-2xl font-semibold">🧭 תקציר (TL;DR)</h2>
+      <ul class="list-disc pr-5 space-y-2">
+        <li>Nadlaner אוסף רק פרטי קשר בסיסיים ונתוני שימוש לצורכי שירות ושיפור חוויה.</li>
+        <li>לא נמכור את פרטיך ולא נשתף מידע אישי ללא סיבה מוצדקת.</li>
+        <li>תוכל לבקש לעיין, לעדכן או למחוק את פרטיך בכל עת.</li>
+        <li>שימוש באתר מהווה הסכמה למדיניות זו ולתנאי השימוש.</li>
+      </ul>
+    </section>
+  </main>
+
+  <footer class="border-t border-neutral-200 bg-white py-6">
+    <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 text-sm text-neutral-600 flex flex-wrap justify-between gap-4">
+      <p>© 2025 נדל״נר. כל הזכויות שמורות.</p>
+      <div class="flex items-center gap-3">
+        <a href="/terms-of-use.html" class="hover:underline">תנאי שימוש</a>
+        <span aria-hidden="true">•</span>
+        <a href="/" class="hover:underline">דף הבית</a>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/nadlaner-marketing/terms-of-use.html
+++ b/nadlaner-marketing/terms-of-use.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="he" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>תנאי שימוש באתר Nadlaner</title>
+  <meta name="description" content="תנאי השימוש המלאים של אתר Nadlaner, המעודכנים ל-6 באוקטובר 2025." />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+  <link rel="canonical" href="https://www.nadlaner.com/terms-of-use" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, "Inter", sans-serif; }
+    :focus-visible { outline: 2px solid #0ea5e9; outline-offset: 2px; }
+  </style>
+</head>
+<body class="bg-neutral-50 text-neutral-900">
+  <header class="border-b border-neutral-200 bg-white">
+    <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
+      <a href="/" class="flex items-center gap-2">
+        <img src="/favicon-32.png" alt="לוגו נדל״נר" width="32" height="32" loading="lazy" decoding="async" class="w-7 h-7" />
+        <span class="font-bold text-teal-600">נדל"נר</span>
+      </a>
+      <a href="/" class="text-sm text-teal-600 hover:underline">חזרה לדף הבית</a>
+    </div>
+  </header>
+
+  <main class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-10 space-y-8">
+    <section class="space-y-4">
+      <h1 class="text-3xl font-bold">🧾 תנאי שימוש באתר Nadlaner</h1>
+      <p class="text-sm text-neutral-500">עודכן לאחרונה: 6 באוקטובר 2025</p>
+      <p>ברוך הבא לאתר Nadlaner ("האתר"), המופעל על ידי איתמר מזרחי ("המפעיל", "אנחנו"). השימוש באתר ובשירותיו כפוף לתנאים המפורטים להלן. השימוש באתר מהווה הסכמה לכל תנאי השימוש. אם אינך מסכים – אנא הימנע מלהשתמש באתר.</p>
+    </section>
+
+    <section class="space-y-3">
+      <h2 class="text-2xl font-semibold">1. מטרת האתר</h2>
+      <p>Nadlaner הוא פלטפורמה מקוונת המספקת למשתמשים מידע, ניתוחים והערכות שווי לנכסים בישראל, בהתבסס על מקורות מידע ציבוריים ופרטיים, לרבות מאגרי נדל״ן ממשלתיים, נתוני שוק ותוכן גולשים.</p>
+    </section>
+
+    <section class="space-y-3">
+      <h2 class="text-2xl font-semibold">2. שימוש באתר</h2>
+      <ul class="list-disc pr-5 space-y-2">
+        <li>האתר מיועד לשימוש אישי בלבד ואינו מהווה ייעוץ משפטי, שמאי, פיננסי או אחר.</li>
+        <li>המשתמש מצהיר כי הוא בגיר (מעל גיל 18) ומוסמך להתקשר בהסכם זה.</li>
+        <li>אין לעשות שימוש באתר לצורך ביצוע עבירה, פגיעה בזכויות צדדים שלישיים, או פעולה העלולה לפגוע בפעילות האתר.</li>
+        <li>המפעיל רשאי להגביל או לחסום גישה למשתמשים לפי שיקול דעתו.</li>
+      </ul>
+    </section>
+
+    <section class="space-y-3">
+      <h2 class="text-2xl font-semibold">3. אחריות מוגבלת</h2>
+      <ul class="list-disc pr-5 space-y-2">
+        <li>השירותים באתר ניתנים "כמות שהם" (AS IS) ללא אחריות מכל סוג.</li>
+        <li>המידע עשוי להתבסס על מקורות חיצוניים (כגון govmap, nadlan.gov, MAVAT) ולכן ייתכנו טעויות, עיכובים או אי-דיוקים.</li>
+        <li>המפעיל לא יישא באחריות לכל נזק ישיר או עקיף, הפסד כספי או תביעה הנובעים מהסתמכות על מידע באתר.</li>
+        <li>המשתמש אחראי הבלעדי לבדוק את המידע מול מקורות מוסמכים לפני קבלת החלטות.</li>
+      </ul>
+    </section>
+
+    <section class="space-y-3">
+      <h2 class="text-2xl font-semibold">4. קניין רוחני</h2>
+      <ul class="list-disc pr-5 space-y-2">
+        <li>כל זכויות היוצרים והקניין הרוחני באתר, לרבות עיצוב, קוד, טקסטים, לוגו, תוכן, תמונות ואלגוריתמים — שייכים למפעיל בלבד.</li>
+        <li>אין לשכפל, להעתיק, להפיץ או לעשות שימוש מסחרי כלשהו בתכנים ללא רשות בכתב.</li>
+        <li>סימני מסחר ושמות מסחריים שייכים לבעליהם החוקיים.</li>
+      </ul>
+    </section>
+
+    <section class="space-y-3">
+      <h2 class="text-2xl font-semibold">5. תוכן משתמשים</h2>
+      <ul class="list-disc pr-5 space-y-2">
+        <li>המשתמש אחראי לכל תוכן שהוא מעלה לאתר (כגון הערות, טפסים או קבצים).</li>
+        <li>המשתמש מצהיר שהתוכן אינו מפר זכויות יוצרים או דין כלשהו.</li>
+        <li>המפעיל רשאי להסיר תוכן לפי שיקול דעתו.</li>
+      </ul>
+    </section>
+
+    <section class="space-y-3">
+      <h2 class="text-2xl font-semibold">6. שינוי והפסקת השירות</h2>
+      <ul class="list-disc pr-5 space-y-2">
+        <li>המפעיל רשאי לשנות את מבנה האתר, תוכנו או השירותים המוצעים בו, בכל עת, ללא הודעה מוקדמת.</li>
+        <li>המפעיל רשאי להפסיק את פעילות האתר באופן זמני או קבוע.</li>
+        <li>במקרה של שינוי מהותי בתנאי השימוש, תפורסם הודעה באתר.</li>
+      </ul>
+    </section>
+
+    <section class="space-y-3">
+      <h2 class="text-2xl font-semibold">7. שיפוי</h2>
+      <p>המשתמש מתחייב לשפות את המפעיל בגין כל נזק, תביעה או הוצאה (כולל שכר טרחת עו"ד) הנובעים מהפרת תנאי שימוש אלה או מפעולה אסורה מצד המשתמש.</p>
+    </section>
+
+    <section class="space-y-3">
+      <h2 class="text-2xl font-semibold">8. הדין החל וסמכות השיפוט</h2>
+      <p>הדין החל הוא הדין הישראלי בלבד, וסמכות השיפוט הבלעדית נתונה לבתי המשפט המוסמכים בעיר תל-אביב-יפו.</p>
+    </section>
+  </main>
+
+  <footer class="border-t border-neutral-200 bg-white py-6">
+    <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 text-sm text-neutral-600 flex flex-wrap justify-between gap-4">
+      <p>© 2025 נדל״נר. כל הזכויות שמורות.</p>
+      <div class="flex items-center gap-3">
+        <a href="/privacy-policy.html" class="hover:underline">מדיניות פרטיות</a>
+        <span aria-hidden="true">•</span>
+        <a href="/" class="hover:underline">דף הבית</a>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add standalone Hebrew terms of use and privacy policy pages for the Nadlaner marketing site
- update the marketing site footer links to point to the new legal pages and surface a TL;DR privacy summary

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68e4200f1a4483288640708688f09d86