### PR TITLE
Update observability metrics server default port

### DIFF
--- a/orchestration/data_pipeline.py
+++ b/orchestration/data_pipeline.py
@@ -309,7 +309,7 @@ class DataPipeline:
         # Note: GovMap client is now accessed through the collector
 
         # Expose Prometheus metrics endpoint
-        start_metrics_server(int(os.getenv("METRICS_PORT", "8000")))
+        start_metrics_server(int(os.getenv("METRICS_PORT", "9000")))
 
         # Ensure database is ready when we manage it ourselves.
         if self.db is not None:

--- a/orchestration/observability.py
+++ b/orchestration/observability.py
@@ -61,7 +61,7 @@ COLLECTOR_FAILURE = Counter(
 _metrics_started = False
 _metrics_server = None
 
-def start_metrics_server(port: int = 8000) -> None:
+def start_metrics_server(port: int = 9000) -> None:
     global _metrics_started, _metrics_server
     if _metrics_started:
         logger.debug("Metrics server already started; skipping start for port %s", port)


### PR DESCRIPTION
## Summary
- change the observability metrics server default port to 9000
- update the data pipeline to use the new default port unless overridden via METRICS_PORT

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4b2b60b5c8328882ef618da8f4624