### PR TITLE
Handle numeric block and parcel inputs in GIS collector

### DIFF
--- a/orchestration/collectors/gis_collector.py
+++ b/orchestration/collectors/gis_collector.py
@@ -33,9 +33,12 @@ class GISCollector(BaseCollector):
         number = query.house_number or 0
 
         # Handle block/parcel-only queries
-        if block and parcel and block.strip() and parcel.strip() and not search_street:
+        block_str = str(block).strip() if block is not None else ""
+        parcel_str = str(parcel).strip() if parcel is not None else ""
+
+        if block_str and parcel_str and not search_street:
             logger.info(f"Processing block/parcel-only query: {block}/{parcel}")
-            return self._collect_by_block_parcel(block, parcel)
+            return self._collect_by_block_parcel(block_str, parcel_str)
 
         if not search_street:
             raise ValueError("GISCollector requires at least a street name or block/parcel")


### PR DESCRIPTION
## Summary
- normalize block and parcel inputs to strings before validation
- ensure block/parcel-only lookups work when numeric identifiers are provided

## Testing
- pytest tests/orchestration -k gis --maxfail=1

------
https://chatgpt.com/codex/tasks/task_e_68e4b2e36db883288d2736990e8eb94b