### PR TITLE
Fix property mapping and strengthen related tests

### DIFF
--- a/docs/alert-system.md
+++ b/docs/alert-system.md
@@ -92,10 +92,8 @@ cd backend-django
 python manage.py test_alerts
 ```
 
-#### Using Test Script
-```bash
-python test_alerts.py
-```
+> **Note:** The legacy `test_alerts.py` helper script has been removed. Use the Django
+> management command above for all alert verification workflows.
 
 #### Testing Specific Channels
 ```bash

--- a/docs/code-review-tasks.md
+++ b/docs/code-review-tasks.md
@@ -1,0 +1,21 @@
+# Code Review Findings (Jan 2025)
+
+## 1. Fix Typo in Marketing Site Pricing Table
+- **Issue**: The Hebrew label for the business plan is misspelled as "עיסקי" instead of the correct "עסקי".
+- **Location**: `nadlaner-marketing/index.html`, lines 436-448.
+- **Proposed Task**: Update the heading and call-to-action text to use the correct spelling to avoid presenting a typo on the public marketing page.
+
+## 2. Correct Property Type Code Mapping Bug
+- **Issue**: `PropertyTypeUtils.search_hebrew_name_to_code` returns incorrect Yad2 codes for several property types (e.g., `'דירת גן'` maps to `34` instead of `3`, `'גג'` maps to `35` instead of `6`).
+- **Location**: `yad2/utils/property_types.py`, lines 123-155.
+- **Proposed Task**: Align the fallback search mapping with the authoritative mapping used elsewhere in the module so that partial-name lookups return the same codes as the canonical translation tables.
+
+## 3. Fix Alert System Documentation Discrepancy
+- **Issue**: The alert system guide instructs running `python test_alerts.py`, but no such script exists. Only the Django management command is available.
+- **Location**: `docs/alert-system.md`, lines 95-99.
+- **Proposed Task**: Update the documentation to reference the supported management command (and/or add the missing script) so readers do not follow a broken instruction.
+
+## 4. Strengthen Mavat Collector Integration Tests
+- **Issue**: Two integration tests only contain `assert True`, providing no real coverage.
+- **Location**: `tests/mavat/test_collector_integration.py`, lines 13-52.
+- **Proposed Task**: Replace the placeholder assertions with real import checks (e.g., actually importing the classes) so the tests fail when modules are missing.

--- a/nadlaner-marketing/index.html
+++ b/nadlaner-marketing/index.html
@@ -434,7 +434,7 @@
         </div>
         <!-- Business plan -->
         <div class="rounded-2xl border border-neutral-200 bg-white p-6">
-          <h3 class="text-lg font-semibold">עיסקי</h3>
+          <h3 class="text-lg font-semibold">עסקי</h3>
           <p class="mt-1 text-3xl font-extrabold">₪799<span class="text-base text-neutral-500">/חודש</span></p>
           <p class="text-sm text-neutral-500">לצוותים מקצועיים</p>
           <ul class="mt-4 space-y-2 text-sm text-neutral-700">
@@ -445,7 +445,7 @@
             <li>• תמיכה עדיפה ו-SLA</li>
             <li>• גישה ל-API ואינטגרציות</li>
           </ul>
-          <a href="https://app.nadlaner.com/signup?plan=pro" class="btn btn-secondary mt-5 w-full">בחר עיסקי</a>
+          <a href="https://app.nadlaner.com/signup?plan=pro" class="btn btn-secondary mt-5 w-full">בחר עסקי</a>
         </div>
       </div>
       <div class="text-center mt-8">

--- a/tests/mavat/test_collector_integration.py
+++ b/tests/mavat/test_collector_integration.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 """Integration tests for MavatCollector."""
 
+from importlib import import_module
+from inspect import isclass
 from unittest.mock import Mock, patch
 
 import pytest
@@ -13,9 +15,13 @@ class TestMavatCollectorIntegration:
     def test_collector_import(self):
         """Test that MavatCollector can be imported."""
         try:
-            assert True
+            module = import_module("orchestration.collectors.mavat_collector")
+            mavat_cls = getattr(module, "MavatCollector")
+            assert isclass(mavat_cls), "MavatCollector is not a class"
         except ImportError as e:
-            pytest.fail(f"Failed to import MavatCollector: {e}")
+            pytest.fail(f"Failed to import MavatCollector module: {e}")
+        except AttributeError as e:
+            pytest.fail(f"MavatCollector class missing: {e}")
 
     def test_collector_creation(self):
         """Test that MavatCollector can be created."""
@@ -46,9 +52,13 @@ class TestMavatCollectorDataPipelineIntegration:
     def test_data_pipeline_import(self):
         """Test that DataPipeline can import MavatCollector."""
         try:
-            assert True
+            module = import_module("orchestration.data_pipeline")
+            pipeline_cls = getattr(module, "DataPipeline")
+            assert isclass(pipeline_cls), "DataPipeline is not a class"
         except ImportError as e:
-            pytest.fail(f"Failed to import DataPipeline or MavatCollector: {e}")
+            pytest.fail(f"Failed to import DataPipeline module: {e}")
+        except AttributeError as e:
+            pytest.fail(f"DataPipeline class missing: {e}")
 
     def test_data_pipeline_has_mavat_collector(self):
         """Test that DataPipeline includes MavatCollector."""

--- a/tests/yad2/test_property_types.py
+++ b/tests/yad2/test_property_types.py
@@ -1,0 +1,46 @@
+"""Tests for Yad2 property type utilities."""
+
+import pytest
+
+from yad2.utils.property_types import PropertyTypeUtils
+
+
+@pytest.mark.parametrize(
+    "name, expected_code",
+    [
+        ("דירת גן", 3),
+        ("גג", 6),
+        ("בית פרטי", 39),
+    ],
+)
+def test_hebrew_name_to_code_returns_canonical_mapping(name, expected_code):
+    """Ensure the canonical Hebrew mapping returns the correct Yad2 code."""
+    assert PropertyTypeUtils.hebrew_name_to_code(name) == expected_code
+
+
+@pytest.mark.parametrize(
+    "search_term, expected_name, expected_code",
+    [
+        ("דירת גן", "דירת גן", 3),
+        ("גן", "דירת גן", 3),
+        ("פנטהאוס", "מיני פנטהאוס", 6),
+        ("גג", "גג", 6),
+    ],
+)
+def test_search_hebrew_name_to_code_matches_canonical_results(
+    search_term, expected_name, expected_code
+):
+    """Search results should reuse the canonical mapping values."""
+    results = PropertyTypeUtils.search_hebrew_name_to_code(search_term)
+    assert results, "Expected search to return at least one match"
+
+    results_dict = {name: code for code, name in results}
+    assert results_dict[expected_name] == expected_code
+    assert results_dict[expected_name] == PropertyTypeUtils.hebrew_name_to_code(expected_name)
+
+
+def test_search_results_are_sorted_by_name():
+    """Ensure deterministic ordering for downstream callers and tests."""
+    results = PropertyTypeUtils.search_hebrew_name_to_code("בית")
+    sorted_names = sorted(name for _, name in results)
+    assert [name for _, name in results] == sorted_names

--- a/yad2/utils/property_types.py
+++ b/yad2/utils/property_types.py
@@ -13,7 +13,47 @@ from datetime import datetime
 
 class PropertyTypeUtils:
     """Utility class for property type operations."""
-    
+
+    _HEBREW_TO_CODE = {
+        # Main property types - matching official parameters.py
+        'דירה': 1,                    # Apartment
+        'דירה עם גינה': 3,            # Apartment with Garden
+        'נטהאוס': 6,                  # Penthouse
+        'דופלקס': 7,                  # Duplex
+        'מלון': 25,                   # Hotel
+        'מרתף': 49,                   # Basement
+        'טריפלקס': 51,                # Triplex
+        'דירה משנית': 11,             # Sub-apartment
+        'סטודיו': 4,                  # Studio
+        'קוטג': 5,                    # Cottage
+        'וילה': 5,                    # Cottage (synonym)
+        'בית דו משפחתי': 39,          # Two-family house
+        'משק חקלאי': 32,              # Agricultural farm
+        'חצר': 52,                    # Farm
+        'קרקע': 33,                   # Land
+        'בית בטוח': 61,               # Safe house
+        'ממ"ד': 61,                   # Safe house (synonym)
+        'בניין': 44,                  # Building
+        'גראז': 45,                   # Garage
+        'חניה': 30,                   # Parking
+        'דירה עתידית': 50,            # Future apartment
+
+        # Additional Hebrew names for better coverage
+        'בית פרטי': 39,               # Two-family house (same as בית דו משפחתי)
+        'בית': 39,                    # Two-family house (same as בית דו משפחתי)
+        'דירת גן': 3,                 # Apartment with Garden (same as דירה עם גינה)
+        'גג': 6,                      # Penthouse (same as נטהאוס)
+        'יחידה': 1,                   # Apartment (same as דירה)
+        'מיני פנטהאוס': 6,           # Penthouse (same as נטהאוס)
+        'לופט': 7,                    # Duplex (same as דופלקס)
+        'דירת נופש': 25,              # Hotel (same as מלון)
+        'בית מלון': 25,               # Hotel (same as מלון)
+        'מרחב מוגן דירתי': 61,       # Safe house (same as ממ"ד)
+        'בית דו-משפחתי': 39,          # Two-family house
+        'דו משפחתי': 39,              # Two-family house
+        'דו-משפחתי': 39,              # Two-family house
+    }
+
     @staticmethod
     def translate_to_english(hebrew_name):
         """Translate Hebrew property type names to English."""
@@ -38,43 +78,7 @@ class PropertyTypeUtils:
     @staticmethod
     def hebrew_name_to_code(hebrew_name):
         """Convert Hebrew property type names to Yad2 codes."""
-        hebrew_to_code = {
-            # Main property types - matching official parameters.py
-            'דירה': 1,                    # Apartment
-            'דירה עם גינה': 3,            # Apartment with Garden
-            'נטהאוס': 6,                  # Penthouse
-            'דופלקס': 7,                  # Duplex
-            'מלון': 25,                   # Hotel
-            'מרתף': 49,                   # Basement
-            'טריפלקס': 51,                # Triplex
-            'דירה משנית': 11,             # Sub-apartment
-            'סטודיו': 4,                  # Studio
-            'קוטג': 5,                    # Cottage
-            'וילה': 5,                    # Cottage (synonym)
-            'בית דו משפחתי': 39,          # Two-family house
-            'משק חקלאי': 32,              # Agricultural farm
-            'חצר': 52,                    # Farm
-            'קרקע': 33,                   # Land
-            'בית בטוח': 61,               # Safe house
-            'ממ"ד': 61,                   # Safe house (synonym)
-            'בניין': 44,                  # Building
-            'גראז': 45,                   # Garage
-            'חניה': 30,                   # Parking
-            'דירה עתידית': 50,            # Future apartment
-            
-            # Additional Hebrew names for better coverage
-            'בית פרטי': 39,               # Two-family house (same as בית דו משפחתי)
-            'בית': 39,                    # Two-family house (same as בית דו משפחתי)
-            'דירת גן': 3,                 # Apartment with Garden (same as דירה עם גינה)
-            'גג': 6,                      # Penthouse (same as נטהאוס)
-            'יחידה': 1,                   # Apartment (same as דירה)
-            'מיני פנטהאוס': 6,           # Penthouse (same as נטהאוס)
-            'לופט': 7,                    # Duplex (same as דופלקס)
-            'דירת נופש': 25,              # Hotel (same as מלון)
-            'בית מלון': 25,               # Hotel (same as מלון)
-            'מרחב מוגן דירתי': 61,       # Safe house (same as ממ"ד)
-        }
-        return hebrew_to_code.get(hebrew_name, None)
+        return PropertyTypeUtils._HEBREW_TO_CODE.get(hebrew_name, None)
     
     @staticmethod
     def english_name_to_code(english_name):
@@ -120,49 +124,21 @@ class PropertyTypeUtils:
     @staticmethod
     def search_hebrew_name_to_code(search_term):
         """Search for Hebrew property type names and return matching codes."""
-        hebrew_to_code = {
-            'דירה': 1,
-            'דירה עם גינה': 3,
-            'נטהאוס': 6,
-            'דופלקס': 7,
-            'קוטג': 5,  # Updated: קוטג instead of וילה
-            'וילה': 5,  # Keep for backward compatibility
-            'בית': 39,  # Fixed: בית should be Single-family house (39), not Villa (5)
-            'בית פרטי': 39,  # Fixed: בית פרטי should be Single-family house (39), not Villa (5)
-            'בית דו משפחתי': 39,  # Fixed: בית דו משפחתי should be Two-family house (39)
-            'בית דו-משפחתי': 39,  # Fixed: בית דו-משפחתי should be Two-family house (39)
-            'דו משפחתי': 39,  # Fixed: דו משפחתי should be Two-family house (39)
-            'דו-משפחתי': 39,  # Fixed: דו-משפחתי should be Two-family house (39)
-            'קרקע': 33,
-            'בניין': 44,
-            'גראז': 45,
-            'חניה': 30,
-            'דירה עתידית': 50,
-            'דירת גן': 34,
-            'גג': 35,
-            'יחידה': 36,
-            'מיני פנטהאוס': 37,
-            'טריפלקס': 32,
-            'לופט': 31,
-            'מלון': 25,
-            'מרתף': 49,
-            'דירת נופש': 25,
-            'בית מלון': 25,
-            'חצר': 52,
-            'משק חקלאי': 32,
-            'בית בטוח': 61,
-            'ממ"ד': 61,
-            'מרחב מוגן דירתי': 61
-        }
-        
-        # Search for partial matches
+        if not search_term:
+            return []
+
         matching_codes = []
         search_term_lower = search_term.lower()
-        
-        for hebrew_name, code in hebrew_to_code.items():
-            if search_term_lower in hebrew_name.lower() or hebrew_name.lower() in search_term_lower:
+
+        for hebrew_name, code in PropertyTypeUtils._HEBREW_TO_CODE.items():
+            hebrew_name_lower = hebrew_name.lower()
+            if (
+                search_term_lower in hebrew_name_lower
+                or hebrew_name_lower in search_term_lower
+            ):
                 matching_codes.append((code, hebrew_name))
-        
+
+        matching_codes.sort(key=lambda item: item[1])
         return matching_codes
     
     @staticmethod
@@ -332,12 +308,12 @@ class PropertyTypeUtils:
             'גראז': {'code': 45, 'english': 'Garage', 'description': 'חניה/גראז'},
             'חניה': {'code': 30, 'english': 'Parking', 'description': 'חניה'},
             'דירה עתידית': {'code': 50, 'english': 'Future apartment', 'description': 'דירה עתידית'},
-            'דירת גן': {'code': 34, 'english': 'Garden Apartment', 'description': 'דירת גן'},
-            'גג': {'code': 35, 'english': 'Rooftop', 'description': 'גג'},
-            'יחידה': {'code': 36, 'english': 'Unit', 'description': 'יחידה'},
-            'מיני פנטהאוס': {'code': 37, 'english': 'Mini Penthouse', 'description': 'מיני פנטהאוס'},
-            'טריפלקס': {'code': 32, 'english': 'Triplex', 'description': 'טריפלקס'},
-            'לופט': {'code': 31, 'english': 'Loft', 'description': 'לופט'},
+            'דירת גן': {'code': 3, 'english': 'Garden Apartment', 'description': 'דירת גן'},
+            'גג': {'code': 6, 'english': 'Rooftop', 'description': 'גג'},
+            'יחידה': {'code': 1, 'english': 'Unit', 'description': 'יחידה'},
+            'מיני פנטהאוס': {'code': 6, 'english': 'Mini Penthouse', 'description': 'מיני פנטהאוס'},
+            'טריפלקס': {'code': 51, 'english': 'Triplex', 'description': 'טריפלקס'},
+            'לופט': {'code': 7, 'english': 'Loft', 'description': 'לופט'},
             'מלון': {'code': 25, 'english': 'Hotel', 'description': 'מלון'},
             'מרתף': {'code': 49, 'english': 'Basement', 'description': 'מרתף'},
             'דירת נופש': {'code': 25, 'english': 'Vacation apartment', 'description': 'דירת נופש'},


### PR DESCRIPTION
## Summary
- correct the marketing business plan label to use the proper Hebrew spelling
- align the Yad2 property type search with the canonical mapping and document the canonical codes
- update alert-system docs to reference the supported Django command instead of a missing script
- harden integration tests around the Mavat collector and add regression tests for property type lookups

## Testing
- pytest tests/yad2/test_property_types.py tests/mavat/test_collector_integration.py

------
https://chatgpt.com/codex/tasks/task_e_68e5045a111483288152effd6b2323d5